### PR TITLE
fix(core): reduce API calls by fetching labels, assignees, createdAt in GraphQL query

### DIFF
--- a/src/adapter/repositories/issue/ApiV3CheerioRestIssueRepository.test.ts
+++ b/src/adapter/repositories/issue/ApiV3CheerioRestIssueRepository.test.ts
@@ -28,6 +28,9 @@ describe('ApiV3CheerioRestIssueRepository', () => {
             state: 'OPEN',
             url: 'https://github.com/HiromiShikata/test-repository/issues/38',
             body: 'test-body',
+            labels: [],
+            assignees: [],
+            createdAt: '2024-01-01T00:00:00Z',
             customFields: [
               { name: 'nextActionDate', value: '2000-01-01' },
               { name: 'nextActionHour', value: '1' },
@@ -59,13 +62,13 @@ describe('ApiV3CheerioRestIssueRepository', () => {
           completionDate50PercentConfidence: null,
           isInProgress: false,
           isClosed: false,
-          createdAt: new Date('2024-01-01'),
+          createdAt: new Date('2024-01-01T00:00:00Z'),
         },
       },
     ];
-    test.each(testCases)('%s', async (arg) => {
+    test.each(testCases)('%s', (arg) => {
       const { repository } = createApiV3CheerioRestIssueRepository();
-      const result = await repository.convertProjectItemToIssue(...arg.params);
+      const result = repository.convertProjectItemToIssue(...arg.params);
       expect(result).toEqual(arg.expected);
     });
   });

--- a/src/adapter/repositories/issue/GraphqlProjectItemRepository.ts
+++ b/src/adapter/repositories/issue/GraphqlProjectItemRepository.ts
@@ -10,6 +10,9 @@ export type ProjectItem = {
   state: 'OPEN' | 'CLOSED' | 'MERGED';
   url: string;
   body: string;
+  labels: string[];
+  assignees: string[];
+  createdAt: string;
   customFields: {
     name: string;
     value: string | null;
@@ -144,9 +147,20 @@ query GetProjectItems($projectId: ID!, $after: String) {
             ... on Issue {
               number
               title
-              state 
+              state
               url
               body
+              createdAt
+              labels(first: 100) {
+                nodes {
+                  name
+                }
+              }
+              assignees(first: 20) {
+                nodes {
+                  login
+                }
+              }
               repository {
                 nameWithOwner
               }
@@ -157,6 +171,17 @@ query GetProjectItems($projectId: ID!, $after: String) {
               state
               url
               body
+              createdAt
+              labels(first: 100) {
+                nodes {
+                  name
+                }
+              }
+              assignees(first: 20) {
+                nodes {
+                  login
+                }
+              }
               repository {
                 nameWithOwner
               }
@@ -199,6 +224,9 @@ query GetProjectItems($projectId: ID!, $after: String) {
               state: string;
               url: string;
               body: string;
+              createdAt: string;
+              labels: { nodes: { name: string }[] };
+              assignees: { nodes: { login: string }[] };
             };
           }[];
         };
@@ -240,6 +268,9 @@ query GetProjectItems($projectId: ID!, $after: String) {
                   state: string;
                   url: string;
                   body: string;
+                  createdAt: string;
+                  labels: { nodes: { name: string }[] };
+                  assignees: { nodes: { login: string }[] };
                 };
               }[];
             };
@@ -259,19 +290,7 @@ query GetProjectItems($projectId: ID!, $after: String) {
       }
       return response.data.data;
     };
-    const issues: {
-      id: string;
-      nameWithOwner: string;
-      number: number;
-      title: string;
-      state: 'OPEN' | 'CLOSED' | 'MERGED';
-      url: string;
-      body: string;
-      customFields: {
-        name: string;
-        value: string | null;
-      }[];
-    }[] = [];
+    const issues: ProjectItem[] = [];
     let after: string | null = null;
     let hasNextPage = true;
 
@@ -297,6 +316,9 @@ query GetProjectItems($projectId: ID!, $after: String) {
           state: string;
           url: string;
           body: string;
+          createdAt: string;
+          labels: { nodes: { name: string }[] };
+          assignees: { nodes: { login: string }[] };
         };
       }[] = data.node.items.nodes;
       projectItems
@@ -313,6 +335,9 @@ query GetProjectItems($projectId: ID!, $after: String) {
             state: this.convertStrToState(item.content.state),
             url: item.content.url,
             body: item.content.body,
+            labels: item.content.labels?.nodes?.map((l) => l.name) || [],
+            assignees: item.content.assignees?.nodes?.map((a) => a.login) || [],
+            createdAt: item.content.createdAt || new Date().toISOString(),
             customFields: item.fieldValues.nodes
               .filter((field) => !!field.field)
               .map((field) => {
@@ -509,6 +534,17 @@ query GetProjectFields($owner: String!, $repository: String!, $issueNumber: Int!
       state
       url
       body
+      createdAt
+      labels(first: 100) {
+        nodes {
+          name
+        }
+      }
+      assignees(first: 20) {
+        nodes {
+          login
+        }
+      }
       repository {
         nameWithOwner
       }
@@ -582,6 +618,9 @@ query GetProjectFields($owner: String!, $repository: String!, $issueNumber: Int!
             state: string;
             url: string;
             body: string;
+            createdAt: string;
+            labels: { nodes: { name: string }[] };
+            assignees: { nodes: { login: string }[] };
             repository: { nameWithOwner: string };
             projectItems: {
               nodes: {
@@ -641,6 +680,10 @@ query GetProjectFields($owner: String!, $repository: String!, $issueNumber: Int!
       state: this.convertStrToState(data.repository.issue.state),
       url: data.repository.issue.url,
       body: data.repository.issue.body,
+      labels: data.repository.issue.labels?.nodes?.map((l) => l.name) || [],
+      assignees:
+        data.repository.issue.assignees?.nodes?.map((a) => a.login) || [],
+      createdAt: data.repository.issue.createdAt || new Date().toISOString(),
       customFields: item.fieldValues.nodes
         .filter((field) => !!field.field)
         .map((field) => {


### PR DESCRIPTION
## Summary
- Modified GraphqlProjectItemRepository.ts to include labels, assignees, and createdAt in the fetchProjectItems and fetchProjectItemByUrl GraphQL queries
- Updated ProjectItem type to include the new fields
- Removed redundant REST API call in convertProjectItemToIssue that was causing excessive API rate limit hits (N+1 query problem)
- Simplified getAllIssuesFromGitHub by removing unnecessary batch processing

## Root Cause
The `convertProjectItemToIssue` method was calling `restIssueRepository.getIssue(item.url)` for **each** issue in the project to fetch labels, assignees, and created_at. With 100 issues, this resulted in 100 REST API calls, quickly exceeding the API rate limit.

## Solution
Fetch labels, assignees, and createdAt directly in the GraphQL query alongside other issue data, eliminating the need for additional REST API calls.

## Test plan
- [x] Run unit tests for ApiV3CheerioRestIssueRepository
- [x] Run unit tests for GraphqlProjectItemRepository
- [x] Verify lint passes
- [x] Verify build passes

- close #311