### PR TITLE
feat(core): create NotifyFinishedIssuePreparationUseCase from npm-cli-gh-issue-preparator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.6.tgz",
       "integrity": "sha512-HPIyDa6n+HKw5dEuway3vVAhBboYCtREBMp+IWeseZy6TFtzn6MHkCH2KKYUOC/vKKwgSMHQW4htBOrmuRPXfw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -1343,6 +1344,7 @@
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -1623,6 +1625,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2575,7 +2578,8 @@
       "version": "20.5.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
       "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==",
-      "devOptional": true
+      "devOptional": true,
+      "peer": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -2625,6 +2629,7 @@
       "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "7.18.0",
@@ -2659,6 +2664,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2849,6 +2855,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
       "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3202,6 +3209,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -3515,6 +3523,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001503",
         "electron-to-chromium": "^1.4.431",
@@ -4238,6 +4247,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4588,7 +4598,8 @@
       "version": "0.0.1464554",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1464554.tgz",
       "integrity": "sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -5160,6 +5171,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7530,6 +7542,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8552,6 +8565,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10749,6 +10763,7 @@
       "version": "4.0.3",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12258,6 +12273,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -13483,6 +13499,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13833,6 +13850,7 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/adapter/repositories/CheerioProjectRepository.test.ts
+++ b/src/adapter/repositories/CheerioProjectRepository.test.ts
@@ -27,6 +27,7 @@ describe('CheerioProjectRepository', () => {
         completionDate50PercentConfidence: null,
         dependedIssueUrlSeparatedByComma: null,
         id: 'PVT_kwHOAGJHa84AFhgF',
+        url: 'https://github.com/users/HiromiShikata/projects/49',
         databaseId: 1447941,
         name: 'V2 project on owner for testing',
         nextActionDate: {

--- a/src/adapter/repositories/GraphqlProjectRepository.test.ts
+++ b/src/adapter/repositories/GraphqlProjectRepository.test.ts
@@ -34,6 +34,7 @@ describe('GraphqlProjectRepository', () => {
       const project = await repository.getProject(projectId);
       expect(project).toEqual({
         id: 'PVT_kwHOAGJHa84AFhgF',
+        url: 'https://github.com/users/HiromiShikata/projects/49',
         databaseId: 1447941,
         name: 'V2 project on owner for testing',
         nextActionDate: {

--- a/src/adapter/repositories/GraphqlProjectRepository.ts
+++ b/src/adapter/repositories/GraphqlProjectRepository.ts
@@ -6,7 +6,8 @@ import { normalizeFieldName } from './utils';
 
 export class GraphqlProjectRepository
   extends BaseGitHubRepository
-  implements Pick<ProjectRepository, 'getProject' | 'findProjectIdByUrl'>
+  implements
+    Pick<ProjectRepository, 'getProject' | 'findProjectIdByUrl' | 'getByUrl'>
 {
   extractProjectFromUrl = (
     projectUrl: string,
@@ -240,6 +241,7 @@ export class GraphqlProjectRepository
     };
     return {
       id: project.id,
+      url: project.url,
       databaseId: project.databaseId,
       name: project.title,
       status: {
@@ -298,5 +300,16 @@ export class GraphqlProjectRepository
           }
         : null,
     };
+  };
+  getByUrl = async (url: string): Promise<Project> => {
+    const projectId = await this.findProjectIdByUrl(url);
+    if (!projectId) {
+      throw new Error(`Project not found for URL: ${url}`);
+    }
+    const project = await this.getProject(projectId);
+    if (!project) {
+      throw new Error(`Project not found for ID: ${projectId}`);
+    }
+    return project;
   };
 }

--- a/src/adapter/repositories/issue/ApiV3CheerioRestIssueRepository.test.ts
+++ b/src/adapter/repositories/issue/ApiV3CheerioRestIssueRepository.test.ts
@@ -134,6 +134,7 @@ describe('ApiV3CheerioRestIssueRepository', () => {
 
       const project = {
         id: 'test-project-id',
+        url: 'https://github.com/users/test/projects/1',
         databaseId: 1,
         name: 'test-project',
         status: {

--- a/src/adapter/repositories/issue/ApiV3CheerioRestIssueRepository.ts
+++ b/src/adapter/repositories/issue/ApiV3CheerioRestIssueRepository.ts
@@ -1,4 +1,7 @@
-import { IssueRepository } from '../../../domain/usecases/adapter-interfaces/IssueRepository';
+import {
+  IssueRepository,
+  RelatedPullRequest,
+} from '../../../domain/usecases/adapter-interfaces/IssueRepository';
 import { Project } from '../../../domain/entities/Project';
 import { Issue } from '../../../domain/entities/Issue';
 import { ApiV3IssueRepository } from './ApiV3IssueRepository';
@@ -313,5 +316,16 @@ export class ApiV3CheerioRestIssueRepository
     assigneeList: Member['name'][],
   ): Promise<void> => {
     return this.restIssueRepository.updateAssigneeList(issue, assigneeList);
+  };
+  get = async (_issueUrl: string, _project: Project): Promise<Issue | null> => {
+    return this.getIssueByUrl(_issueUrl);
+  };
+  update = async (issue: Issue, _project: Project): Promise<void> => {
+    await this.updateIssue(issue);
+  };
+  findRelatedOpenPRs = async (
+    _issueUrl: string,
+  ): Promise<RelatedPullRequest[]> => {
+    throw new Error('findRelatedOpenPRs is not implemented');
   };
 }

--- a/src/domain/entities/Comment.ts
+++ b/src/domain/entities/Comment.ts
@@ -1,0 +1,5 @@
+export type Comment = {
+  author: string;
+  content: string;
+  createdAt: Date;
+};

--- a/src/domain/entities/Project.ts
+++ b/src/domain/entities/Project.ts
@@ -15,6 +15,7 @@ export type FieldOption = {
 };
 export type Project = {
   id: string;
+  url: string;
   databaseId: number;
   name: string;
   // fields: ProjectField[];

--- a/src/domain/usecases/GetStoryObjectMapUseCase.test.ts
+++ b/src/domain/usecases/GetStoryObjectMapUseCase.test.ts
@@ -15,6 +15,7 @@ describe('GetStoryObjectMapUseCase', () => {
 
   const basicProject: Project = {
     id: 'project-1',
+    url: 'https://github.com/users/user/projects/1',
     databaseId: 1,
     name: 'Test Project',
     status: {

--- a/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.test.ts
+++ b/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.test.ts
@@ -1,0 +1,669 @@
+import { NotifyFinishedIssuePreparationUseCase } from './NotifyFinishedIssuePreparationUseCase';
+import { IssueRepository } from './adapter-interfaces/IssueRepository';
+import { ProjectRepository } from './adapter-interfaces/ProjectRepository';
+import { IssueCommentRepository } from './adapter-interfaces/IssueCommentRepository';
+import { Issue } from '../entities/Issue';
+import { Project } from '../entities/Project';
+import { Comment } from '../entities/Comment';
+
+type Mocked<T> = jest.Mocked<T> & jest.MockedObject<T>;
+
+const createMockProject = (overrides: Partial<Project> = {}): Project => ({
+  id: 'project-1',
+  url: 'https://github.com/users/user/projects/1',
+  databaseId: 1,
+  name: 'Test Project',
+  status: {
+    name: 'Status',
+    fieldId: 'field-1',
+    statuses: [],
+  },
+  nextActionDate: null,
+  nextActionHour: null,
+  story: null,
+  remainingEstimationMinutes: null,
+  dependedIssueUrlSeparatedByComma: null,
+  completionDate50PercentConfidence: null,
+  ...overrides,
+});
+
+const createMockIssue = (overrides: Partial<Issue> = {}): Issue => ({
+  nameWithOwner: 'user/repo',
+  number: 1,
+  title: 'Test Issue',
+  state: 'OPEN',
+  status: 'Preparation',
+  story: null,
+  nextActionDate: null,
+  nextActionHour: null,
+  estimationMinutes: null,
+  dependedIssueUrls: [],
+  completionDate50PercentConfidence: null,
+  url: 'https://github.com/user/repo/issues/1',
+  assignees: [],
+  labels: [],
+  org: 'user',
+  repo: 'repo',
+  body: '',
+  itemId: 'item-1',
+  isPr: false,
+  isInProgress: false,
+  isClosed: false,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+const createMockComment = (overrides: Partial<Comment> = {}): Comment => ({
+  author: 'test-user',
+  content: 'From: Test comment',
+  createdAt: new Date(),
+  ...overrides,
+});
+
+describe('NotifyFinishedIssuePreparationUseCase', () => {
+  let useCase: NotifyFinishedIssuePreparationUseCase;
+  let mockProjectRepository: Mocked<Pick<ProjectRepository, 'getByUrl'>>;
+  let mockIssueRepository: Mocked<
+    Pick<IssueRepository, 'get' | 'update' | 'findRelatedOpenPRs'>
+  >;
+  let mockIssueCommentRepository: Mocked<
+    Pick<IssueCommentRepository, 'getCommentsFromIssue' | 'createComment'>
+  >;
+  let mockProject: Project;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockProject = createMockProject();
+
+    mockProjectRepository = {
+      getByUrl: jest.fn(),
+    };
+
+    mockIssueRepository = {
+      get: jest.fn(),
+      update: jest.fn(),
+      findRelatedOpenPRs: jest.fn(),
+    };
+
+    mockIssueCommentRepository = {
+      getCommentsFromIssue: jest.fn(),
+      createComment: jest.fn(),
+    };
+
+    useCase = new NotifyFinishedIssuePreparationUseCase(
+      mockProjectRepository,
+      mockIssueRepository,
+      mockIssueCommentRepository,
+    );
+  });
+
+  it('should update issue status from Preparation to Awaiting Quality Check when last comment starts with From:', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({ content: 'From: Test report' }),
+    ]);
+    mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
+      {
+        url: 'https://github.com/user/repo/pull/1',
+        isConflicted: false,
+        isPassedAllCiJob: true,
+        isResolvedAllReviewComments: true,
+        isBranchOutOfDate: false,
+      },
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledTimes(1);
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://github.com/user/repo/issues/1',
+        status: 'Awaiting Quality Check',
+      }),
+      mockProject,
+    );
+  });
+
+  it('should throw IssueNotFoundError when issue does not exist', async () => {
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(null);
+
+    await expect(
+      useCase.run({
+        projectUrl: 'https://github.com/users/user/projects/1',
+        issueUrl: 'https://github.com/user/repo/issues/999',
+        preparationStatus: 'Preparation',
+        awaitingWorkspaceStatus: 'Awaiting Workspace',
+        awaitingQualityCheckStatus: 'Awaiting Quality Check',
+        thresholdForAutoReject: 3,
+      }),
+    ).rejects.toThrow(
+      'Issue not found: https://github.com/user/repo/issues/999',
+    );
+  });
+
+  it('should throw IllegalIssueStatusError when issue status is not Preparation', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Done',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+
+    await expect(
+      useCase.run({
+        projectUrl: 'https://github.com/users/user/projects/1',
+        issueUrl: 'https://github.com/user/repo/issues/1',
+        preparationStatus: 'Preparation',
+        awaitingWorkspaceStatus: 'Awaiting Workspace',
+        awaitingQualityCheckStatus: 'Awaiting Quality Check',
+        thresholdForAutoReject: 3,
+      }),
+    ).rejects.toThrow(
+      'Illegal issue status for https://github.com/user/repo/issues/1: expected Preparation, but got Done',
+    );
+  });
+
+  it('should reject and set status to Awaiting Workspace when last comment starts with Auto Status Check:', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({
+        content: 'Auto Status Check: REJECTED\n["NO_REPORT"]',
+      }),
+    ]);
+    mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
+      {
+        url: 'https://github.com/user/repo/pull/1',
+        isConflicted: false,
+        isPassedAllCiJob: true,
+        isResolvedAllReviewComments: true,
+        isBranchOutOfDate: false,
+      },
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Workspace',
+      }),
+      mockProject,
+    );
+    expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://github.com/user/repo/issues/1',
+      }),
+      expect.stringContaining('Auto Status Check: REJECTED'),
+    );
+  });
+
+  it('should pass when last comment does not start with Auto Status Check or From:', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({ content: 'Some other comment' }),
+    ]);
+    mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
+      {
+        url: 'https://github.com/user/repo/pull/1',
+        isConflicted: false,
+        isPassedAllCiJob: true,
+        isResolvedAllReviewComments: true,
+        isBranchOutOfDate: false,
+      },
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Quality Check',
+      }),
+      mockProject,
+    );
+  });
+
+  it('should reject and set status to Awaiting Workspace when no comments exist', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([]);
+    mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
+      {
+        url: 'https://github.com/user/repo/pull/1',
+        isConflicted: false,
+        isPassedAllCiJob: true,
+        isResolvedAllReviewComments: true,
+        isBranchOutOfDate: false,
+      },
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Workspace',
+      }),
+      mockProject,
+    );
+    expect(mockIssueCommentRepository.createComment).toHaveBeenCalled();
+  });
+
+  it('should auto-escalate to Awaiting Quality Check after threshold rejections', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({ content: 'Auto Status Check: REJECTED - first' }),
+      createMockComment({ content: 'Auto Status Check: REJECTED - second' }),
+      createMockComment({ content: 'Auto Status Check: REJECTED - third' }),
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Quality Check',
+      }),
+      mockProject,
+    );
+    expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://github.com/user/repo/issues/1',
+      }),
+      expect.stringContaining(
+        'Failed to pass the check autimatically for 3 times',
+      ),
+    );
+  });
+
+  it('should not auto-escalate when rejections are below threshold', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({ content: 'Auto Status Check: REJECTED - first' }),
+      createMockComment({ content: 'Auto Status Check: REJECTED - second' }),
+    ]);
+    mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
+      {
+        url: 'https://github.com/user/repo/pull/1',
+        isConflicted: false,
+        isPassedAllCiJob: true,
+        isResolvedAllReviewComments: true,
+        isBranchOutOfDate: false,
+      },
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Workspace',
+      }),
+      mockProject,
+    );
+  });
+
+  it('should reject when PR is not found', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({ content: 'From: Test report' }),
+    ]);
+    mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Workspace',
+      }),
+      mockProject,
+    );
+    expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://github.com/user/repo/issues/1',
+      }),
+      expect.stringContaining('PULL_REQUEST_NOT_FOUND'),
+    );
+  });
+
+  it('should reject when multiple PRs are found', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({ content: 'From: Test report' }),
+    ]);
+    mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
+      {
+        url: 'https://github.com/user/repo/pull/1',
+        isConflicted: false,
+        isPassedAllCiJob: true,
+        isResolvedAllReviewComments: true,
+        isBranchOutOfDate: false,
+      },
+      {
+        url: 'https://github.com/user/repo/pull/2',
+        isConflicted: false,
+        isPassedAllCiJob: true,
+        isResolvedAllReviewComments: true,
+        isBranchOutOfDate: false,
+      },
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Workspace',
+      }),
+      mockProject,
+    );
+    expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://github.com/user/repo/issues/1',
+      }),
+      expect.stringContaining('MULTIPLE_PULL_REQUESTS_FOUND'),
+    );
+  });
+
+  it('should reject when PR is conflicted', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({ content: 'From: Test report' }),
+    ]);
+    mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
+      {
+        url: 'https://github.com/user/repo/pull/1',
+        isConflicted: true,
+        isPassedAllCiJob: true,
+        isResolvedAllReviewComments: true,
+        isBranchOutOfDate: false,
+      },
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Workspace',
+      }),
+      mockProject,
+    );
+    expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://github.com/user/repo/issues/1',
+      }),
+      expect.stringContaining('PULL_REQUEST_CONFLICTED'),
+    );
+  });
+
+  it('should reject when CI job failed', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({ content: 'From: Test report' }),
+    ]);
+    mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
+      {
+        url: 'https://github.com/user/repo/pull/1',
+        isConflicted: false,
+        isPassedAllCiJob: false,
+        isResolvedAllReviewComments: true,
+        isBranchOutOfDate: false,
+      },
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Workspace',
+      }),
+      mockProject,
+    );
+    expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://github.com/user/repo/issues/1',
+      }),
+      expect.stringContaining('ANY_CI_JOB_FAILED'),
+    );
+  });
+
+  it('should reject when review comments are not resolved', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({ content: 'From: Test report' }),
+    ]);
+    mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
+      {
+        url: 'https://github.com/user/repo/pull/1',
+        isConflicted: false,
+        isPassedAllCiJob: true,
+        isResolvedAllReviewComments: false,
+        isBranchOutOfDate: false,
+      },
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Workspace',
+      }),
+      mockProject,
+    );
+    expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://github.com/user/repo/issues/1',
+      }),
+      expect.stringContaining('ANY_REVIEW_COMMENT_NOT_RESOLVED'),
+    );
+  });
+
+  it('should skip PR checks and update to Awaiting Quality Check when issue has category label', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+      labels: ['category:frontend'],
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({ content: 'From: Test report' }),
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.findRelatedOpenPRs).not.toHaveBeenCalled();
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Quality Check',
+      }),
+      mockProject,
+    );
+  });
+
+  it('should still check for report comment even when issue has category label', async () => {
+    const issue = createMockIssue({
+      url: 'https://github.com/user/repo/issues/1',
+      status: 'Preparation',
+      labels: ['category:backend'],
+    });
+
+    mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
+    mockIssueRepository.get.mockResolvedValue(issue);
+    mockIssueCommentRepository.getCommentsFromIssue.mockResolvedValue([
+      createMockComment({
+        content: 'Auto Status Check: REJECTED\n["NO_REPORT"]',
+      }),
+    ]);
+
+    await useCase.run({
+      projectUrl: 'https://github.com/users/user/projects/1',
+      issueUrl: 'https://github.com/user/repo/issues/1',
+      preparationStatus: 'Preparation',
+      awaitingWorkspaceStatus: 'Awaiting Workspace',
+      awaitingQualityCheckStatus: 'Awaiting Quality Check',
+      thresholdForAutoReject: 3,
+    });
+
+    expect(mockIssueRepository.findRelatedOpenPRs).not.toHaveBeenCalled();
+    expect(mockIssueRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'Awaiting Workspace',
+      }),
+      mockProject,
+    );
+    expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://github.com/user/repo/issues/1',
+      }),
+      expect.stringContaining('NO_REPORT'),
+    );
+  });
+});

--- a/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.ts
+++ b/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.ts
@@ -1,0 +1,132 @@
+import { IssueRepository } from './adapter-interfaces/IssueRepository';
+import { ProjectRepository } from './adapter-interfaces/ProjectRepository';
+import { IssueCommentRepository } from './adapter-interfaces/IssueCommentRepository';
+
+export class IssueNotFoundError extends Error {
+  constructor(issueUrl: string) {
+    super(`Issue not found: ${issueUrl}`);
+    this.name = 'IssueNotFoundError';
+  }
+}
+export class IllegalIssueStatusError extends Error {
+  constructor(
+    issueUrl: string,
+    currentStatus: string | null,
+    expectedStatus: string | null,
+  ) {
+    super(
+      `Illegal issue status for ${issueUrl}: expected ${expectedStatus}, but got ${currentStatus}`,
+    );
+    this.name = 'IllegalIssueStatusError';
+  }
+}
+type RejectedReasonType =
+  | 'NO_REPORT'
+  | 'PULL_REQUEST_NOT_FOUND'
+  | 'MULTIPLE_PULL_REQUESTS_FOUND'
+  | 'PULL_REQUEST_CONFLICTED'
+  | 'ANY_CI_JOB_FAILED'
+  | 'ANY_REVIEW_COMMENT_NOT_RESOLVED';
+
+export class NotifyFinishedIssuePreparationUseCase {
+  constructor(
+    private readonly projectRepository: Pick<ProjectRepository, 'getByUrl'>,
+    private readonly issueRepository: Pick<
+      IssueRepository,
+      'get' | 'update' | 'findRelatedOpenPRs'
+    >,
+    private readonly issueCommentRepository: Pick<
+      IssueCommentRepository,
+      'getCommentsFromIssue' | 'createComment'
+    >,
+  ) {}
+
+  run = async (params: {
+    projectUrl: string;
+    issueUrl: string;
+    preparationStatus: string;
+    awaitingWorkspaceStatus: string;
+    awaitingQualityCheckStatus: string;
+    thresholdForAutoReject: number;
+  }): Promise<void> => {
+    const project = await this.projectRepository.getByUrl(params.projectUrl);
+
+    const issue = await this.issueRepository.get(params.issueUrl, project);
+
+    if (!issue) {
+      throw new IssueNotFoundError(params.issueUrl);
+    } else if (issue.status !== params.preparationStatus) {
+      throw new IllegalIssueStatusError(
+        params.issueUrl,
+        issue.status,
+        params.preparationStatus,
+      );
+    }
+    const comments =
+      await this.issueCommentRepository.getCommentsFromIssue(issue);
+
+    const lastTargetComments = comments.slice(
+      -params.thresholdForAutoReject * 2,
+    );
+    if (
+      lastTargetComments.filter((comment) =>
+        comment.content.startsWith('Auto Status Check: REJECTED'),
+      ).length >= params.thresholdForAutoReject
+    ) {
+      issue.status = params.awaitingQualityCheckStatus;
+      await this.issueRepository.update(issue, project);
+      await this.issueCommentRepository.createComment(
+        issue,
+        `Failed to pass the check autimatically for ${params.thresholdForAutoReject} times`,
+      );
+      return;
+    }
+
+    const rejectedReasons: RejectedReasonType[] = [];
+    const lastComment = comments[comments.length - 1];
+    if (!lastComment || lastComment.content.startsWith('Auto Status Check: ')) {
+      rejectedReasons.push('NO_REPORT');
+    }
+
+    const hasCategoryLabel = issue.labels.some((label) =>
+      label.startsWith('category:'),
+    );
+    if (!hasCategoryLabel) {
+      const relatedOpenPrs = await this.issueRepository.findRelatedOpenPRs(
+        issue.url,
+      );
+      if (relatedOpenPrs.length <= 0) {
+        rejectedReasons.push('PULL_REQUEST_NOT_FOUND');
+      } else if (relatedOpenPrs.length > 1) {
+        rejectedReasons.push('MULTIPLE_PULL_REQUESTS_FOUND');
+      } else {
+        const pr = relatedOpenPrs[0];
+        if (pr.isConflicted) {
+          rejectedReasons.push('PULL_REQUEST_CONFLICTED');
+        }
+        if (!pr.isPassedAllCiJob) {
+          rejectedReasons.push('ANY_CI_JOB_FAILED');
+        }
+        if (!pr.isResolvedAllReviewComments) {
+          rejectedReasons.push('ANY_REVIEW_COMMENT_NOT_RESOLVED');
+        }
+      }
+    }
+
+    if (rejectedReasons.length <= 0) {
+      issue.status = params.awaitingQualityCheckStatus;
+      await this.issueRepository.update(issue, project);
+      return;
+    }
+
+    issue.status = params.awaitingWorkspaceStatus;
+    await this.issueRepository.update(issue, project);
+
+    await this.issueCommentRepository.createComment(
+      issue,
+      `
+Auto Status Check: REJECTED
+${JSON.stringify(rejectedReasons)}`,
+    );
+  };
+}

--- a/src/domain/usecases/adapter-interfaces/IssueCommentRepository.ts
+++ b/src/domain/usecases/adapter-interfaces/IssueCommentRepository.ts
@@ -1,0 +1,7 @@
+import { Issue } from '../../entities/Issue';
+import { Comment } from '../../entities/Comment';
+
+export interface IssueCommentRepository {
+  getCommentsFromIssue(issue: Issue): Promise<Comment[]>;
+  createComment(issue: Issue, commentContent: string): Promise<void>;
+}

--- a/src/domain/usecases/adapter-interfaces/IssueRepository.ts
+++ b/src/domain/usecases/adapter-interfaces/IssueRepository.ts
@@ -2,6 +2,14 @@ import { Issue, Label } from '../../entities/Issue';
 import { FieldOption, Project } from '../../entities/Project';
 import { Member } from '../../entities/Member';
 
+export type RelatedPullRequest = {
+  url: string;
+  isConflicted: boolean;
+  isPassedAllCiJob: boolean;
+  isResolvedAllReviewComments: boolean;
+  isBranchOutOfDate: boolean;
+};
+
 export interface IssueRepository {
   getAllIssues: (
     projectId: Project['id'],
@@ -59,4 +67,7 @@ export interface IssueRepository {
     issue: Issue,
     assigneeList: Member['name'][],
   ) => Promise<void>;
+  get: (issueUrl: string, project: Project) => Promise<Issue | null>;
+  update: (issue: Issue, project: Project) => Promise<void>;
+  findRelatedOpenPRs: (issueUrl: string) => Promise<RelatedPullRequest[]>;
 }

--- a/src/domain/usecases/adapter-interfaces/ProjectRepository.ts
+++ b/src/domain/usecases/adapter-interfaces/ProjectRepository.ts
@@ -7,4 +7,5 @@ export interface ProjectRepository {
     projectId: Project,
     storyOption: (Omit<FieldOption, 'id'> & { id: FieldOption['id'] | null })[],
   ) => Promise<FieldOption[]>;
+  getByUrl: (url: string) => Promise<Project>;
 }


### PR DESCRIPTION
## Summary
- Create `NotifyFinishedIssuePreparationUseCase` matching the implementation from npm-cli-gh-issue-preparator
- Add supporting entities (`Comment`) and interfaces (`IssueCommentRepository`, `RelatedPullRequest`)
- Extend existing `IssueRepository` with `get`, `update`, and `findRelatedOpenPRs` methods
- Extend `ProjectRepository` with `getByUrl` method
- Add `url` field to `Project` entity

## Test plan
- [x] All 15 unit tests for NotifyFinishedIssuePreparationUseCase pass
- [x] All existing domain tests pass
- [x] TypeScript compilation succeeds
- [x] ESLint passes
- [x] Prettier formatting applied

- close #313