### PR TITLE
feat(core): add parent issue link to auto-created child issue description

### DIFF
--- a/src/domain/usecases/ConvertCheckboxToIssueInStoryIssueUseCase.test.ts
+++ b/src/domain/usecases/ConvertCheckboxToIssueInStoryIssueUseCase.test.ts
@@ -212,10 +212,38 @@ describe('ConvertCheckboxToIssueInStoryIssueUseCase', () => {
           storyObjectMap: basicStoryObjectMap,
         },
         expectedCreateNewIssueCalls: [
-          ['org', 'repo', 'Task 1', '', [], []],
-          ['org', 'repo', 'Task 2', '', [], []],
-          ['org', 'repo', 'Task 3', '', [], []],
-          ['org', 'repo', 'Task 4', '', [], []],
+          [
+            'org',
+            'repo',
+            'Task 1',
+            '- Parent issue: https://github.com/org/repo/issues/123',
+            [],
+            [],
+          ],
+          [
+            'org',
+            'repo',
+            'Task 2',
+            '- Parent issue: https://github.com/org/repo/issues/123',
+            [],
+            [],
+          ],
+          [
+            'org',
+            'repo',
+            'Task 3',
+            '- Parent issue: https://github.com/org/repo/issues/456',
+            [],
+            [],
+          ],
+          [
+            'org',
+            'repo',
+            'Task 4',
+            '- Parent issue: https://github.com/org/repo/issues/456',
+            [],
+            [],
+          ],
         ],
         expectedUpdateIssueCalls: [
           [
@@ -306,10 +334,38 @@ describe('ConvertCheckboxToIssueInStoryIssueUseCase', () => {
           storyObjectMap: basicStoryObjectMap,
         },
         expectedCreateNewIssueCalls: [
-          ['org', 'repo', 'Task 1', '', [], []],
-          ['org', 'repo', 'Task 2 for `Story 1 #123`', '', [], []],
-          ['org', 'repo', 'Task 3', '', [], []],
-          ['org', 'repo', 'Task 4', '', [], []],
+          [
+            'org',
+            'repo',
+            'Task 1',
+            '- Parent issue: https://github.com/org/repo/issues/123',
+            [],
+            [],
+          ],
+          [
+            'org',
+            'repo',
+            'Task 2 for `Story 1 #123`',
+            '- Parent issue: https://github.com/org/repo/issues/123',
+            [],
+            [],
+          ],
+          [
+            'org',
+            'repo',
+            'Task 3',
+            '- Parent issue: https://github.com/org/repo/issues/456',
+            [],
+            [],
+          ],
+          [
+            'org',
+            'repo',
+            'Task 4',
+            '- Parent issue: https://github.com/org/repo/issues/456',
+            [],
+            [],
+          ],
         ],
         expectedUpdateIssueCalls: [
           [
@@ -441,8 +497,22 @@ describe('ConvertCheckboxToIssueInStoryIssueUseCase', () => {
           ]),
         },
         expectedCreateNewIssueCalls: [
-          ['orgA', 'repoA', 'Task 1', '', [], []],
-          ['orgB', 'repoB', 'Task 2', '', [], []],
+          [
+            'orgA',
+            'repoA',
+            'Task 1',
+            '- Parent issue: https://github.com/org/repo/issues/123',
+            [],
+            [],
+          ],
+          [
+            'orgB',
+            'repoB',
+            'Task 2',
+            '- Parent issue: https://github.com/org/repo/issues/456',
+            [],
+            [],
+          ],
         ],
         expectedUpdateIssueCalls: [
           [

--- a/src/domain/usecases/ConvertCheckboxToIssueInStoryIssueUseCase.ts
+++ b/src/domain/usecases/ConvertCheckboxToIssueInStoryIssueUseCase.ts
@@ -49,11 +49,12 @@ export class ConvertCheckboxToIssueInStoryIssueUseCase {
           'STORYNAME',
           `${storyOption.name} #${storyIssue.number}`,
         );
+        const newIssueBody = `- Parent issue: ${storyIssue.url}`;
         const newIssueNumber = await this.issueRepository.createNewIssue(
           storyIssue.org,
           storyIssue.repo,
           issueTitle,
-          '',
+          newIssueBody,
           [],
           [],
         );


### PR DESCRIPTION
## Summary
- When creating child issues from checkboxes in story issues, the child issue description now includes a parent issue link in the format `- Parent issue: ${story issue url}`
- Previously, child issues were created with an empty body

## Test plan
- [x] Updated unit tests in `ConvertCheckboxToIssueInStoryIssueUseCase.test.ts` to verify the new body format
- [x] All 12 existing tests pass with the updated expectations
- [x] TypeScript compilation passes
- [x] Lint and format checks pass

- close #329