### PR TITLE
test(console): add Playwright browser E2E for the console UI and wire into CI

### DIFF
--- a/.github/workflows/console-ui.yml
+++ b/.github/workflows/console-ui.yml
@@ -34,8 +34,25 @@ jobs:
       - name: Type check (console UI)
         run: npx tsc --noEmit -p src/adapter/entry-points/console/ui/tsconfig.json
 
+      - name: Type check (console UI E2E)
+        run: npm run console-ui:e2e:typecheck
+
       - name: Build console UI (Vite)
         run: npm run build:console-ui
+
+      - name: Install Playwright browsers (console UI E2E)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run console UI browser E2E (Playwright)
+        run: npx playwright test --config src/adapter/entry-points/console/ui/e2e/playwright.config.ts
+
+      - name: Upload console UI E2E report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: console-ui-e2e-report
+          path: src/adapter/entry-points/console/ui/e2e/report
+          if-no-files-found: ignore
 
       - name: Build Storybook (console UI)
         run: npm run console-ui:build-storybook

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,7 @@ reports
 *.diff
 tmp
 src/adapter/entry-points/console/ui/storybook-static
+test-results
+src/adapter/entry-points/console/ui/e2e/report
+src/adapter/entry-points/console/ui/e2e/test-results
+playwright/.cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.0",
+        "@playwright/test": "1.60.0",
         "@radix-ui/react-slot": "^1.2.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^13.0.0",
@@ -2619,6 +2620,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -14633,6 +14650,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "build": "tsc -p ./tsconfig.build.json",
     "postbuild": "node scripts/copyConsoleUiDist.mjs",
     "console-ui:lint": "biome check src/adapter/entry-points/console/ui",
+    "console-ui:e2e:typecheck": "tsc --noEmit -p src/adapter/entry-points/console/ui/e2e/tsconfig.json",
+    "console-ui:e2e": "npm run build:console-ui && playwright test --config src/adapter/entry-points/console/ui/e2e/playwright.config.ts",
     "console-ui:storybook": "storybook dev -p 6006 -c src/adapter/entry-points/console/ui/.storybook",
     "console-ui:build-storybook": "storybook build -c src/adapter/entry-points/console/ui/.storybook -o src/adapter/entry-points/console/ui/storybook-static",
     "test": "jest",
@@ -54,6 +56,7 @@
   "homepage": "https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management#readme",
   "devDependencies": {
     "@biomejs/biome": "^2.2.0",
+    "@playwright/test": "1.60.0",
     "@radix-ui/react-slot": "^1.2.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.0",

--- a/src/adapter/entry-points/console/ui/biome.json
+++ b/src/adapter/entry-points/console/ui/biome.json
@@ -8,7 +8,13 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["src/**", ".storybook/**"]
+    "includes": [
+      "src/**",
+      ".storybook/**",
+      "e2e/**",
+      "!e2e/report/**",
+      "!e2e/test-results/**"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/src/adapter/entry-points/console/ui/e2e/consoleScenario.spec.ts
+++ b/src/adapter/entry-points/console/ui/e2e/consoleScenario.spec.ts
@@ -1,0 +1,89 @@
+import { expect, type Page, test } from '@playwright/test';
+import {
+  type ConsoleE2eHarness,
+  startConsoleE2eHarness,
+} from './consoleTestHarness';
+
+let harness: ConsoleE2eHarness;
+
+test.beforeAll(async () => {
+  harness = await startConsoleE2eHarness();
+});
+
+test.afterAll(async () => {
+  if (harness !== undefined) {
+    await harness.stop();
+  }
+});
+
+const activeTabLabel = (page: Page) =>
+  page.locator('.console-tab[data-active="true"] .console-tab-label');
+
+const tabByLabel = (page: Page, label: string) =>
+  page.locator('.console-tab', { hasText: label });
+
+const tabBadge = (page: Page, label: string) =>
+  tabByLabel(page, label).locator('.console-tab-badge');
+
+const itemRowByText = (page: Page, text: string) =>
+  page.locator('.console-item-row', { hasText: text });
+
+const processSelectedItemViaStatus = async (page: Page): Promise<void> => {
+  const statusButton = page
+    .locator('.console-op-button', { hasText: 'Awaiting Workspace' })
+    .first();
+  await expect(statusButton).toBeVisible();
+  await statusButton.click();
+};
+
+test('processing tabs drives auto-advance and keeps emptied badges at zero', async ({
+  page,
+}) => {
+  await page.goto(harness.appUrl);
+
+  await expect(activeTabLabel(page)).toHaveText('Awaiting Quality Check');
+  await expect(tabBadge(page, 'Awaiting Quality Check')).toHaveText('1');
+  await expect(tabBadge(page, 'Unread')).toHaveText('2');
+  await expect(tabBadge(page, 'Triage')).toHaveText('2');
+  await expect(tabBadge(page, 'Todo by human')).toHaveText('1');
+
+  await itemRowByText(
+    page,
+    'Serve the committed console UI bundle from serveConsole',
+  ).click();
+  const approveButton = page
+    .locator('.console-op-button', { hasText: 'Approve' })
+    .first();
+  await expect(approveButton).toBeVisible();
+  await approveButton.click();
+
+  await expect(activeTabLabel(page)).toHaveText('Triage');
+  await expect(tabByLabel(page, 'Awaiting Quality Check')).toHaveCount(0);
+
+  await itemRowByText(
+    page,
+    'Add Sonnet to Opus weekly-limit fallback routing per token',
+  ).click();
+  await processSelectedItemViaStatus(page);
+  await expect(tabBadge(page, 'Triage')).toHaveText('1');
+  await page.locator('.console-back-button').click();
+
+  await itemRowByText(
+    page,
+    'Publish the generated documentation site to GitHub Pages',
+  ).click();
+  await processSelectedItemViaStatus(page);
+
+  await expect(activeTabLabel(page)).toHaveText('Unread');
+  await expect(tabByLabel(page, 'Triage')).toHaveCount(0);
+
+  await tabByLabel(page, 'Todo by human').click();
+  await expect(activeTabLabel(page)).toHaveText('Todo by human');
+  await expect(tabByLabel(page, 'Triage')).toHaveCount(0);
+  await expect(tabBadge(page, 'Todo by human')).toHaveText('1');
+
+  await tabByLabel(page, 'Unread').click();
+  await expect(activeTabLabel(page)).toHaveText('Unread');
+  await expect(tabByLabel(page, 'Triage')).toHaveCount(0);
+  await expect(tabBadge(page, 'Unread')).toHaveText('2');
+});

--- a/src/adapter/entry-points/console/ui/e2e/consoleTestHarness.ts
+++ b/src/adapter/entry-points/console/ui/e2e/consoleTestHarness.ts
@@ -1,0 +1,378 @@
+import * as fs from 'fs';
+import type * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import type { Issue } from '../../../../../domain/entities/Issue';
+import type { Project } from '../../../../../domain/entities/Project';
+import type {
+  IssueComment,
+  IssueRepository,
+  PullRequestCommit,
+  PullRequestDetail,
+  RelatedPullRequest,
+} from '../../../../../domain/usecases/adapter-interfaces/IssueRepository';
+import type { ConsoleProjectBinding } from '../../consoleOperationApi';
+import { IssueTitleStateCache } from '../../consoleReadApi';
+import { startConsoleServer } from '../../consoleServer';
+
+export const CONSOLE_E2E_PJCODE = 'umino';
+export const CONSOLE_E2E_TOKEN = 'console-e2e-fixture-token-3f9c1a';
+
+type ConsoleFixtureListItem = {
+  number: number;
+  title: string;
+  url: string;
+  repo: string;
+  nameWithOwner: string;
+  projectItemId: string;
+  itemId: string;
+  isPr: boolean;
+  story: string;
+  labels: string[];
+  createdAt: string;
+};
+
+type ConsoleFixtureFieldOption = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+type ConsoleFixtureSnapshot = {
+  pjcode: string;
+  generatedAt: string;
+  statusOptions: ConsoleFixtureFieldOption[];
+  storyOptions: ConsoleFixtureFieldOption[];
+  storyColors: Record<string, { color: string }>;
+  items: ConsoleFixtureListItem[];
+};
+
+const REPO_NAME_WITH_OWNER =
+  'HiromiShikata/npm-cli-github-issue-tower-defence-management';
+
+const AWAITING_WORKSPACE_OPTION: ConsoleFixtureFieldOption = {
+  id: 'd1c19cce',
+  name: 'Awaiting Workspace',
+  color: 'BLUE',
+};
+
+const STATUS_OPTIONS: ConsoleFixtureFieldOption[] = [
+  { id: 'f75ad846', name: 'Unread', color: 'ORANGE' },
+  AWAITING_WORKSPACE_OPTION,
+  { id: 'f57f1ce9', name: 'Preparation', color: 'YELLOW' },
+  { id: 'fd313492', name: 'Failed Preparation', color: 'RED' },
+  { id: 'e9931e57', name: 'Todo by human', color: 'PINK' },
+  { id: 'c2d278b2', name: 'In Tmux by human', color: 'RED' },
+  { id: 'e9f6a726', name: 'In Tmux by agent', color: 'YELLOW' },
+];
+
+const STORY_OPTIONS: ConsoleFixtureFieldOption[] = [
+  { id: '1491051e', name: 'TDPM Console port', color: 'BLUE' },
+  { id: '28415d6c', name: 'regular / workflow improvement', color: 'GRAY' },
+  {
+    id: 'f7cd5cbc',
+    name: 'Publish product documentation site',
+    color: 'GREEN',
+  },
+];
+
+const STORY_COLORS: Record<string, { color: string }> = {
+  'TDPM Console port': { color: 'BLUE' },
+  'regular / workflow improvement': { color: 'GRAY' },
+  'Publish product documentation site': { color: 'GREEN' },
+};
+
+const issueItem = (
+  number: number,
+  title: string,
+  projectItemSuffix: string,
+  story: string,
+  createdAt: string,
+): ConsoleFixtureListItem => ({
+  number,
+  title,
+  url: `https://github.com/${REPO_NAME_WITH_OWNER}/issues/${number}`,
+  repo: REPO_NAME_WITH_OWNER,
+  nameWithOwner: REPO_NAME_WITH_OWNER,
+  projectItemId: `PVTI_lADOABCD1234zg${projectItemSuffix}`,
+  itemId: `PVTI_lADOABCD1234zg${projectItemSuffix}`,
+  isPr: false,
+  story,
+  labels: [],
+  createdAt,
+});
+
+const pullRequestItem = (
+  number: number,
+  title: string,
+  projectItemSuffix: string,
+  story: string,
+  createdAt: string,
+): ConsoleFixtureListItem => ({
+  number,
+  title,
+  url: `https://github.com/${REPO_NAME_WITH_OWNER}/pull/${number}`,
+  repo: REPO_NAME_WITH_OWNER,
+  nameWithOwner: REPO_NAME_WITH_OWNER,
+  projectItemId: `PVTI_lADOABCD1234zg${projectItemSuffix}`,
+  itemId: `PVTI_lADOABCD1234zg${projectItemSuffix}`,
+  isPr: true,
+  story,
+  labels: ['claude'],
+  createdAt,
+});
+
+const buildSnapshot = (
+  items: ConsoleFixtureListItem[],
+): ConsoleFixtureSnapshot => ({
+  pjcode: CONSOLE_E2E_PJCODE,
+  generatedAt: '2026-06-18T01:22:09.000Z',
+  statusOptions: STATUS_OPTIONS,
+  storyOptions: STORY_OPTIONS,
+  storyColors: STORY_COLORS,
+  items,
+});
+
+export const CONSOLE_E2E_TAB_ITEMS: Record<string, ConsoleFixtureListItem[]> = {
+  prs: [
+    pullRequestItem(
+      867,
+      'Serve the committed console UI bundle from serveConsole',
+      'PRS00867',
+      'TDPM Console port',
+      '2026-06-17T23:41:08.000Z',
+    ),
+  ],
+  triage: [
+    issueItem(
+      778,
+      'Add Sonnet to Opus weekly-limit fallback routing per token',
+      'TRI00778',
+      'regular / workflow improvement',
+      '2026-06-12T23:01:55.000Z',
+    ),
+    issueItem(
+      692,
+      'Publish the generated documentation site to GitHub Pages',
+      'TRI00692',
+      'Publish product documentation site',
+      '2026-06-10T11:42:00.000Z',
+    ),
+  ],
+  unread: [
+    issueItem(
+      845,
+      'Scaffold React console UI under entry-points with build bundling',
+      'UNR00845',
+      'TDPM Console port',
+      '2026-06-16T22:01:55.000Z',
+    ),
+    issueItem(
+      853,
+      'Add server-side console API handlers for read and operation endpoints',
+      'UNR00853',
+      'TDPM Console port',
+      '2026-06-17T05:48:09.000Z',
+    ),
+  ],
+  'failed-preparation': [],
+  'todo-by-human': [
+    issueItem(
+      869,
+      'Auto-advance to the next non-empty console tab when one empties',
+      'TODO00869',
+      'TDPM Console port',
+      '2026-06-18T00:14:51.000Z',
+    ),
+  ],
+};
+
+const writeFixtureData = (consoleDataOutputDir: string): void => {
+  for (const [tab, items] of Object.entries(CONSOLE_E2E_TAB_ITEMS)) {
+    const tabDir = path.join(consoleDataOutputDir, CONSOLE_E2E_PJCODE, tab);
+    fs.mkdirSync(tabDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tabDir, 'list.json'),
+      JSON.stringify(buildSnapshot(items)),
+    );
+  }
+};
+
+const buildE2eProject = (): Project => ({
+  id: 'PVT_console_e2e',
+  url: `https://github.com/orgs/HiromiShikata/projects/1`,
+  databaseId: 1,
+  name: 'TDPM',
+  status: {
+    name: 'Status',
+    fieldId: 'PVTSSF_status',
+    statuses: STATUS_OPTIONS.map((option) => ({
+      id: option.id,
+      name: option.name,
+      color: option.color as Project['status']['statuses'][number]['color'],
+      description: '',
+    })),
+  },
+  nextActionDate: { name: 'Next Action Date', fieldId: 'PVTF_nad' },
+  nextActionHour: { name: 'Next Action Hour', fieldId: 'PVTF_nah' },
+  story: {
+    name: 'Story',
+    fieldId: 'PVTSSF_story',
+    databaseId: 2,
+    stories: STORY_OPTIONS.map((option) => ({
+      id: option.id,
+      name: option.name,
+      color: option.color as Project['status']['statuses'][number]['color'],
+      description: '',
+    })),
+    workflowManagementStory: { id: 'wms_1', name: 'regular / workflow' },
+  },
+  remainingEstimationMinutes: null,
+  dependedIssueUrlSeparatedByComma: null,
+  completionDate50PercentConfidence: null,
+});
+
+const buildIssueForUrl = (url: string): Issue => ({
+  nameWithOwner: REPO_NAME_WITH_OWNER,
+  number: 0,
+  title: 'Console E2E fixture issue',
+  state: 'OPEN',
+  status: null,
+  story: null,
+  nextActionDate: null,
+  nextActionHour: null,
+  estimationMinutes: null,
+  dependedIssueUrls: [],
+  completionDate50PercentConfidence: null,
+  url,
+  assignees: [],
+  labels: [],
+  org: 'HiromiShikata',
+  repo: 'npm-cli-github-issue-tower-defence-management',
+  body: 'Console E2E fixture issue body.',
+  itemId: '',
+  isPr: url.includes('/pull/'),
+  isInProgress: false,
+  isClosed: false,
+  createdAt: new Date('2026-06-18T00:00:00.000Z'),
+  author: 'HiromiShikata',
+});
+
+const notImplemented = (method: string): never => {
+  throw new Error(`console E2E stub does not implement ${method}`);
+};
+
+const createStubIssueRepository = (): IssueRepository => ({
+  getAllIssues: () => notImplemented('getAllIssues'),
+  getIssueByUrl: async (url: string): Promise<Issue | null> =>
+    buildIssueForUrl(url),
+  createNewIssue: () => notImplemented('createNewIssue'),
+  searchIssue: () => notImplemented('searchIssue'),
+  updateIssue: () => notImplemented('updateIssue'),
+  updateNextActionDate: async (): Promise<void> => undefined,
+  updateNextActionHour: () => notImplemented('updateNextActionHour'),
+  updateProjectTextField: () => notImplemented('updateProjectTextField'),
+  updateStory: async (): Promise<void> => undefined,
+  updateStatus: async (): Promise<void> => undefined,
+  clearProjectField: () => notImplemented('clearProjectField'),
+  createComment: () => notImplemented('createComment'),
+  updateLabels: () => notImplemented('updateLabels'),
+  removeLabel: () => notImplemented('removeLabel'),
+  updateAssigneeList: () => notImplemented('updateAssigneeList'),
+  get: async (issueUrl: string): Promise<Issue | null> =>
+    buildIssueForUrl(issueUrl),
+  update: () => notImplemented('update'),
+  findRelatedOpenPRs: async (): Promise<RelatedPullRequest[]> => [],
+  getOpenPullRequest: async (): Promise<RelatedPullRequest | null> => null,
+  getPullRequestChangedFilePaths: async (): Promise<string[]> => [],
+  approvePullRequest: async (): Promise<void> => undefined,
+  requestChangesWithInlineComment: async (): Promise<void> => undefined,
+  closePullRequest: async (): Promise<void> => undefined,
+  closeIssueByUrl: async (): Promise<void> => undefined,
+  deletePullRequestBranch: () => notImplemented('deletePullRequestBranch'),
+  createCommentByUrl: async (): Promise<void> => undefined,
+  getAllOpened: () => notImplemented('getAllOpened'),
+  getStoryObjectMap: () => notImplemented('getStoryObjectMap'),
+  addIssueToProject: () => notImplemented('addIssueToProject'),
+  setDependedIssueUrl: () => notImplemented('setDependedIssueUrl'),
+  getIssueOrPullRequestBody: async (): Promise<string> =>
+    '## Console E2E fixture\n\nThis body is served by the isolated E2E stub.',
+  getIssueOrPullRequestComments: async (): Promise<IssueComment[]> => [],
+  getPullRequestDetail: async (): Promise<PullRequestDetail | null> => null,
+  getPullRequestCommits: async (): Promise<PullRequestCommit[]> => [],
+  getIssueOrPullRequestState: async (
+    url: string,
+  ): Promise<{ state: string; merged: boolean; isPullRequest: boolean }> => ({
+    state: 'open',
+    merged: false,
+    isPullRequest: url.includes('/pull/'),
+  }),
+  getPullRequestSummary: async (): Promise<{
+    title: string;
+    body: string;
+    additions: number;
+    deletions: number;
+    changedFiles: number;
+  } | null> => null,
+});
+
+export type ConsoleE2eHarness = {
+  baseUrl: string;
+  appUrl: string;
+  consoleDataOutputDir: string;
+  stop: () => Promise<void>;
+};
+
+export const startConsoleE2eHarness = async (): Promise<ConsoleE2eHarness> => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'console-e2e-'));
+  const consoleDataOutputDir = path.join(tmpRoot, 'data');
+  writeFixtureData(consoleDataOutputDir);
+
+  const uiDistDir = path.resolve(__dirname, '..', '..', 'ui-dist');
+
+  const project = buildE2eProject();
+  const resolveProject = async (
+    pjcode: string,
+  ): Promise<ConsoleProjectBinding | null> =>
+    pjcode === CONSOLE_E2E_PJCODE ? { pjcode, project } : null;
+
+  const server = await startConsoleServer({
+    accessToken: CONSOLE_E2E_TOKEN,
+    uiDistDir,
+    consoleDataOutputDir,
+    issueRepository: createStubIssueRepository(),
+    resolveProject,
+    issueTitleStateCache: new IssueTitleStateCache(),
+    port: 0,
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    await closeServer(server);
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    throw new Error('console E2E server is not listening on a TCP port');
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const appUrl = `${baseUrl}/projects/${CONSOLE_E2E_PJCODE}?k=${CONSOLE_E2E_TOKEN}`;
+
+  return {
+    baseUrl,
+    appUrl,
+    consoleDataOutputDir,
+    stop: async (): Promise<void> => {
+      await closeServer(server);
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    },
+  };
+};
+
+const closeServer = (server: http.Server): Promise<void> =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });

--- a/src/adapter/entry-points/console/ui/e2e/playwright.config.ts
+++ b/src/adapter/entry-points/console/ui/e2e/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: __dirname,
+  testMatch: '**/*.spec.ts',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'report' }]],
+  timeout: 60_000,
+  expect: { timeout: 3_000 },
+  use: {
+    actionTimeout: 3_000,
+    navigationTimeout: 3_000,
+    trace: 'on',
+    screenshot: 'on',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/src/adapter/entry-points/console/ui/e2e/tsconfig.json
+++ b/src/adapter/entry-points/console/ui/e2e/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "ignoreDeprecations": "6.0",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "types": ["node"]
+  },
+  "include": ["."]
+}


### PR DESCRIPTION
## Summary

Adds Playwright browser end-to-end tests for the TDPM Console UI and wires them into the console-ui CI workflow. The tests drive the real UI against an isolated serveConsole instance seeded with deterministic fixture data (never production GitHub), and cover the two behaviours fixed in the pull requests this branch builds on.

## Coverage

- A tab driven to zero keeps its count badge at 0 across tab switches (regression coverage for the count-badge revival fix).
- Processing the last item of a tab auto-advances to the next non-empty tab to the right.

Each screen transition stays under 3 seconds and the whole scenario completes well under 180 seconds. The E2E job runs on every pull request through the console-ui workflow.

## Merge order

The count-badge revival fix is already merged into the default branch. This branch is based on the tab auto-advance pull request and stacks the end-to-end test layer on top of it, layered by file so there are no overlapping edits. Its diff therefore shows only the end-to-end test and continuous-integration wiring on top of the auto-advance branch, with no duplicate of the already-merged badge fix and no duplicate of the auto-advance change. Please merge the auto-advance pull request first, then this one:

https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/pull/872

Closes #870
