### PR TITLE
feat(cli): auto-start web console server at daemon startup

### DIFF
--- a/src/adapter/entry-points/cli/index.test.ts
+++ b/src/adapter/entry-points/cli/index.test.ts
@@ -73,6 +73,11 @@ jest.mock('../handlers/HandleScheduledEventUseCaseHandler', () => ({
     handle: jest.fn().mockResolvedValue(null),
   })),
 }));
+jest.mock('../console/ensureConsoleRunning', () => ({
+  ensureConsoleRunning: jest.fn().mockResolvedValue(null),
+}));
+import * as ensureConsoleRunningModule from '../console/ensureConsoleRunning';
+
 import type { StartConsoleServerOptions } from '../console/consoleServer';
 
 const mockStartConsoleServer = jest
@@ -1204,6 +1209,128 @@ mysteryKey: 'value'
           codexHomeCandidates: ['.codex-readme1', '.codex-readme2'],
         }),
       );
+    });
+
+    it('should start web console before preparation cycle when consoleAccessToken is provided', async () => {
+      const mockRun = jest.fn().mockResolvedValue({ rotationOrder: null });
+      const MockedStartPreparationUseCase = jest.mocked(
+        StartPreparationUseCase,
+      );
+      MockedStartPreparationUseCase.mockImplementation(function (
+        this: StartPreparationUseCase,
+      ) {
+        this.run = mockRun;
+        return this;
+      });
+
+      const mockKill = jest.fn();
+      const callOrder: string[] = [];
+      jest
+        .mocked(ensureConsoleRunningModule.ensureConsoleRunning)
+        .mockImplementationOnce(async () => {
+          callOrder.push('ensureWebConsoleRunning');
+          return { kill: mockKill };
+        });
+      mockRun.mockImplementationOnce(async () => {
+        callOrder.push('preparationRun');
+        return { rotationOrder: null };
+      });
+
+      writeConfig({ ...defaultConfig, consoleAccessToken: 'test-key-abc' });
+
+      await program.parseAsync([
+        'node',
+        'test',
+        'startDaemon',
+        '--configFilePath',
+        configFilePath,
+      ]);
+
+      expect(callOrder).toEqual(['ensureWebConsoleRunning', 'preparationRun']);
+      expect(
+        ensureConsoleRunningModule.ensureConsoleRunning,
+      ).toHaveBeenCalledWith(configFilePath, 9981);
+    });
+
+    it('should not start web console when consoleAccessToken is not provided', async () => {
+      const mockRun = jest.fn().mockResolvedValue({ rotationOrder: null });
+      const MockedStartPreparationUseCase = jest.mocked(
+        StartPreparationUseCase,
+      );
+      MockedStartPreparationUseCase.mockImplementation(function (
+        this: StartPreparationUseCase,
+      ) {
+        this.run = mockRun;
+        return this;
+      });
+
+      jest.mocked(ensureConsoleRunningModule.ensureConsoleRunning).mockClear();
+
+      await program.parseAsync([
+        'node',
+        'test',
+        'startDaemon',
+        '--configFilePath',
+        configFilePath,
+      ]);
+
+      expect(
+        ensureConsoleRunningModule.ensureConsoleRunning,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should register SIGTERM and SIGINT handlers when a new web console process is started', async () => {
+      const mockRun = jest.fn().mockResolvedValue({ rotationOrder: null });
+      const MockedStartPreparationUseCase = jest.mocked(
+        StartPreparationUseCase,
+      );
+      MockedStartPreparationUseCase.mockImplementation(function (
+        this: StartPreparationUseCase,
+      ) {
+        this.run = mockRun;
+        return this;
+      });
+
+      const mockKill = jest.fn();
+      jest
+        .mocked(ensureConsoleRunningModule.ensureConsoleRunning)
+        .mockResolvedValueOnce({ kill: mockKill });
+
+      const processOnceSpy = jest.spyOn(process, 'once');
+
+      writeConfig({ ...defaultConfig, consoleAccessToken: 'test-key-sigterm' });
+
+      await program.parseAsync([
+        'node',
+        'test',
+        'startDaemon',
+        '--configFilePath',
+        configFilePath,
+      ]);
+
+      const sigtermCall = processOnceSpy.mock.calls.find(
+        ([event]) => event === 'SIGTERM',
+      );
+      const sigintCall = processOnceSpy.mock.calls.find(
+        ([event]) => event === 'SIGINT',
+      );
+      expect(sigtermCall).toBeDefined();
+      expect(sigintCall).toBeDefined();
+
+      processOnceSpy.mockRestore();
+
+      const rawSigtermHandler = sigtermCall?.[1];
+      const rawSigintHandler = sigintCall?.[1];
+      if (typeof rawSigtermHandler !== 'function') {
+        throw new Error('Expected SIGTERM handler to be a function');
+      }
+      if (typeof rawSigintHandler !== 'function') {
+        throw new Error('Expected SIGINT handler to be a function');
+      }
+      rawSigtermHandler();
+      expect(mockKill).toHaveBeenCalledTimes(1);
+      rawSigintHandler();
+      expect(mockKill).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/adapter/entry-points/cli/index.ts
+++ b/src/adapter/entry-points/cli/index.ts
@@ -32,6 +32,7 @@ import { GitHubIssueCommentRepository } from '../../repositories/GitHubIssueComm
 import { FetchWebhookRepository } from '../../repositories/FetchWebhookRepository';
 import { RevertOrphanedPreparationUseCase } from '../../../domain/usecases/RevertOrphanedPreparationUseCase';
 import * as path from 'path';
+import { ensureConsoleRunning } from '../console/ensureConsoleRunning';
 import {
   DEFAULT_CONSOLE_PORT,
   startConsoleServer,
@@ -343,6 +344,17 @@ program
       config.codexHomeCandidates && config.codexHomeCandidates.length > 0
         ? config.codexHomeCandidates
         : null;
+
+    if (config.consoleAccessToken) {
+      const consoleProcess = await ensureConsoleRunning(
+        options.configFilePath,
+        DEFAULT_CONSOLE_PORT,
+      );
+      if (consoleProcess !== null) {
+        process.once('SIGTERM', () => consoleProcess.kill());
+        process.once('SIGINT', () => consoleProcess.kill());
+      }
+    }
 
     const preparationResult = await useCase.run({
       projectUrl,

--- a/src/adapter/entry-points/console/ensureConsoleRunning.test.ts
+++ b/src/adapter/entry-points/console/ensureConsoleRunning.test.ts
@@ -1,0 +1,98 @@
+import * as net from 'net';
+
+const spawnCalls: unknown[][] = [];
+const killMock = jest.fn();
+const unrefMock = jest.fn();
+const spawnReturnValue = { unref: unrefMock, kill: killMock };
+
+jest.mock('child_process', () => ({
+  spawn: (...args: unknown[]): { unref: jest.Mock; kill: jest.Mock } => {
+    spawnCalls.push(args);
+    return spawnReturnValue;
+  },
+}));
+
+import { ensureConsoleRunning } from './ensureConsoleRunning';
+
+describe('ensureConsoleRunning', () => {
+  let server: net.Server | null = null;
+
+  const startProbeServer = (): Promise<number> =>
+    new Promise((resolve) => {
+      server = net.createServer((socket) => socket.end());
+      server.listen(0, '127.0.0.1', () => {
+        const address = server?.address();
+        const portValue =
+          address !== null && typeof address === 'object' ? address.port : 0;
+        resolve(portValue);
+      });
+    });
+
+  const findFreePort = (): Promise<number> =>
+    new Promise((resolve) => {
+      const probe = net.createServer();
+      probe.listen(0, '127.0.0.1', () => {
+        const address = probe.address();
+        const portValue =
+          address !== null && typeof address === 'object' ? address.port : 0;
+        probe.close(() => resolve(portValue));
+      });
+    });
+
+  beforeEach(() => {
+    spawnCalls.length = 0;
+    unrefMock.mockReset();
+    killMock.mockReset();
+  });
+
+  afterEach(async () => {
+    if (server !== null) {
+      await new Promise<void>((resolve) => server?.close(() => resolve()));
+      server = null;
+    }
+  });
+
+  it('should short-circuit and return null when the port already responds', async () => {
+    const port = await startProbeServer();
+    const result = await ensureConsoleRunning('/path/to/config.yaml', port);
+    expect(spawnCalls).toHaveLength(0);
+    expect(result).toBeNull();
+  });
+
+  it('should spawn serveConsole when the port is unresponsive', async () => {
+    const unusedPort = await findFreePort();
+    await ensureConsoleRunning('/path/to/config.yaml', unusedPort);
+
+    expect(spawnCalls).toHaveLength(1);
+    const [program, args, options] = spawnCalls[0];
+    expect(program).toBe(process.execPath);
+    if (!Array.isArray(args)) {
+      throw new Error('Expected spawn args to be an array');
+    }
+    expect(args[0]).toMatch(/cli\/index\.js$/);
+    expect(args[1]).toBe('serveConsole');
+    expect(args[2]).toBe('--configFilePath');
+    expect(args[3]).toBe('/path/to/config.yaml');
+    expect(args[4]).toBe('--port');
+    expect(args[5]).toBe(String(unusedPort));
+    const isObject = (value: unknown): value is { [key: string]: unknown } =>
+      value !== null && typeof value === 'object' && !Array.isArray(value);
+    if (!isObject(options)) {
+      throw new Error('Expected spawn options to be an object');
+    }
+    expect(options.detached).toBe(true);
+    expect(options.stdio).toBe('ignore');
+    expect(unrefMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return an object with a kill method when the port is unresponsive', async () => {
+    const unusedPort = await findFreePort();
+    const result = await ensureConsoleRunning(
+      '/path/to/config.yaml',
+      unusedPort,
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('kill');
+    expect(typeof result?.kill).toBe('function');
+  });
+});

--- a/src/adapter/entry-points/console/ensureConsoleRunning.ts
+++ b/src/adapter/entry-points/console/ensureConsoleRunning.ts
@@ -1,0 +1,56 @@
+import { spawn } from 'child_process';
+import * as net from 'net';
+import * as path from 'path';
+
+export interface ConsoleProcess {
+  kill: () => void;
+}
+
+const PROBE_TIMEOUT_MS = 200;
+const STARTUP_WAIT_MS = 1500;
+
+const isPortResponding = (port: number): Promise<boolean> =>
+  new Promise((resolve) => {
+    const socket = new net.Socket();
+    let resolved = false;
+    const cleanup = (result: boolean): void => {
+      if (resolved) return;
+      resolved = true;
+      socket.destroy();
+      resolve(result);
+    };
+    socket.setTimeout(PROBE_TIMEOUT_MS);
+    socket.once('connect', () => cleanup(true));
+    socket.once('timeout', () => cleanup(false));
+    socket.once('error', () => cleanup(false));
+    socket.connect(port, '127.0.0.1');
+  });
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export const ensureConsoleRunning = async (
+  configFilePath: string,
+  port: number,
+): Promise<ConsoleProcess | null> => {
+  if (await isPortResponding(port)) return null;
+  const cliEntry = path.resolve(__dirname, '../cli/index.js');
+  const child = spawn(
+    process.execPath,
+    [
+      cliEntry,
+      'serveConsole',
+      '--configFilePath',
+      configFilePath,
+      '--port',
+      String(port),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+    },
+  );
+  child.unref();
+  await sleep(STARTUP_WAIT_MS);
+  return { kill: () => child.kill() };
+};


### PR DESCRIPTION
Starts the console server as a detached background process before the preparation cycle when `consoleAccessToken` is present in config.

The `ensureConsoleRunning` function is placed in `src/adapter/entry-points/console/` alongside the console server code, where it belongs architecturally — not in the CLI entry point.

- TCP-probe the console port; spawn `serveConsole` as detached child if not already listening
- Register SIGTERM/SIGINT handlers on the daemon process to propagate shutdown to the child
- Add unit tests for `ensureConsoleRunning` (short-circuit, spawn args, kill handle)
- Add integration tests verifying server starts before preparation cycle and SIGTERM/SIGINT propagation

Closes #791