### PR TITLE
feat(token-selection): detect and exclude OAuth tokens with organization-disabled Claude subscription access

### DIFF
--- a/src/adapter/entry-points/handlers/LiveSessionOauthTokenSelectHandler.test.ts
+++ b/src/adapter/entry-points/handlers/LiveSessionOauthTokenSelectHandler.test.ts
@@ -85,6 +85,14 @@ describe('LiveSessionOauthTokenSelectHandler', () => {
     );
   };
 
+  const writeSubscriptionDisabledCache = (token: string): void => {
+    const payload = { subscriptionDisabledEpoch: NOW };
+    fs.writeFileSync(
+      path.join(cacheDirectory, `${hashToken(token)}.json`),
+      JSON.stringify(payload),
+    );
+  };
+
   const buildHandler = (
     sessions: ClaudeLiveSession[],
   ): LiveSessionOauthTokenSelectHandler =>
@@ -288,5 +296,33 @@ describe('LiveSessionOauthTokenSelectHandler', () => {
 
     expect(output.selectedToken).toBeNull();
     expect(output.diagnostics.join('\n')).toContain('No usable token entries');
+  });
+
+  it('excludes a subscription-disabled token even when it has zero live sessions', () => {
+    writeTokenList([
+      { name: 'disabled', token: 'fake-disabled' },
+      { name: 'active', token: 'fake-active' },
+    ]);
+    writeSubscriptionDisabledCache('fake-disabled');
+    writeCache('fake-active', {
+      fiveHourUtilization: 0.1,
+      fiveHourReset: NOW + HOUR,
+      sevenDayUtilization: 0.1,
+      sevenDayReset: NOW + DAY,
+    });
+
+    const handler = buildHandler([
+      { token: 'fake-active', sessionId: 'session-a' },
+    ]);
+    const output = handler.handle({
+      tokenListJsonPath: tokenListPath,
+      cacheDirectory,
+      nowEpochSeconds: NOW,
+    });
+
+    expect(output.selectedName).toBe('active');
+    expect(output.diagnostics.join('\n')).toContain(
+      'organization has disabled Claude subscription access for Claude Code',
+    );
   });
 });

--- a/src/adapter/entry-points/handlers/LiveSessionOauthTokenSelectHandler.ts
+++ b/src/adapter/entry-points/handlers/LiveSessionOauthTokenSelectHandler.ts
@@ -75,6 +75,7 @@ export class LiveSessionOauthTokenSelectHandler {
                 sevenDayUtilization: snapshot.sevenDayUtilization,
                 sevenDayReset: snapshot.sevenDayReset,
               },
+        subscriptionDisabled: snapshot?.subscriptionDisabled ?? false,
       };
     });
 

--- a/src/adapter/entry-points/handlers/OauthTokenSelectHandler.test.ts
+++ b/src/adapter/entry-points/handlers/OauthTokenSelectHandler.test.ts
@@ -78,6 +78,14 @@ describe('OauthTokenSelectHandler', () => {
     );
   };
 
+  const writeSubscriptionDisabledCache = (token: string): void => {
+    const payload = { subscriptionDisabledEpoch: NOW };
+    fs.writeFileSync(
+      path.join(cacheDirectory, `${hashToken(token)}.json`),
+      JSON.stringify(payload),
+    );
+  };
+
   it('selects the eligible token with the soonest 7d reset', () => {
     writeTokenList([
       { name: 'far', token: 'fake-far' },
@@ -166,6 +174,32 @@ describe('OauthTokenSelectHandler', () => {
 
     expect(output.selectedToken).toBeNull();
     expect(output.diagnostics.join('\n')).toContain('No usable token entries');
+  });
+
+  it('excludes a subscription-disabled token even when rate limits are fully free', () => {
+    writeTokenList([
+      { name: 'disabled', token: 'fake-disabled' },
+      { name: 'active', token: 'fake-active' },
+    ]);
+    writeSubscriptionDisabledCache('fake-disabled');
+    writeCache('fake-active', {
+      fiveHourUtilization: 0.1,
+      fiveHourReset: NOW + HOUR,
+      sevenDayUtilization: 0.1,
+      sevenDayReset: NOW + DAY,
+    });
+
+    const handler = new OauthTokenSelectHandler();
+    const output = handler.handle({
+      tokenListJsonPath: tokenListPath,
+      cacheDirectory,
+      nowEpochSeconds: NOW,
+    });
+
+    expect(output.selectedName).toBe('active');
+    expect(output.diagnostics.join('\n')).toContain(
+      'organization has disabled Claude subscription access for Claude Code',
+    );
   });
 
   describe('resolveTokenListJsonPath', () => {

--- a/src/adapter/entry-points/handlers/OauthTokenSelectHandler.ts
+++ b/src/adapter/entry-points/handlers/OauthTokenSelectHandler.ts
@@ -93,6 +93,7 @@ export class OauthTokenSelectHandler {
                 sevenDayUtilization: snapshot.sevenDayUtilization,
                 sevenDayReset: snapshot.sevenDayReset,
               },
+        subscriptionDisabled: snapshot?.subscriptionDisabled ?? false,
       };
     });
 

--- a/src/adapter/proxy/RateLimitCache.test.ts
+++ b/src/adapter/proxy/RateLimitCache.test.ts
@@ -12,6 +12,7 @@ import {
   readRateLimit,
   writeModelRateLimit,
   writeRateLimit,
+  writeSubscriptionDisabled,
 } from './RateLimitCache';
 
 describe('RateLimitCache', () => {
@@ -740,6 +741,58 @@ describe('RateLimitCache', () => {
       expect(snapshot?.modelWeeklyLimits).toEqual({
         seven_day_sonnet: { rejected: true, resetsAt: 1779642000 },
       });
+    });
+  });
+
+  describe('writeSubscriptionDisabled', () => {
+    it('should persist subscriptionDisabledEpoch to the cache file', () => {
+      const token = 'sub-disabled-token';
+      writeSubscriptionDisabled(token);
+      const filePath = cachePathForToken(token);
+      const raw = fs.readFileSync(filePath, 'utf8');
+      const parsed: unknown = JSON.parse(raw);
+      expect(parsed).toMatchObject({
+        subscriptionDisabledEpoch: expect.any(Number),
+      });
+    });
+
+    it('should preserve existing cache fields when writing subscriptionDisabledEpoch', () => {
+      const token = 'sub-disabled-preserve-token';
+      writeRateLimit(token, {
+        'anthropic-ratelimit-unified-5h-status': 'allowed',
+        'anthropic-ratelimit-unified-5h-reset': '2000100',
+        'anthropic-ratelimit-unified-5h-utilization': '0.1',
+        'anthropic-ratelimit-unified-7d-status': 'allowed',
+        'anthropic-ratelimit-unified-7d-reset': '2000200',
+        'anthropic-ratelimit-unified-7d-utilization': '0.1',
+      });
+      writeSubscriptionDisabled(token);
+      const snapshot = readRateLimit(token);
+      expect(snapshot?.subscriptionDisabled).toBe(true);
+      expect(snapshot?.fiveHourReset).toBe(2000100);
+    });
+  });
+
+  describe('readRateLimit subscriptionDisabled', () => {
+    it('returns subscriptionDisabled: true after writeSubscriptionDisabled is called', () => {
+      const token = 'sub-disabled-read-token';
+      writeSubscriptionDisabled(token);
+      const snapshot = readRateLimit(token);
+      expect(snapshot?.subscriptionDisabled).toBe(true);
+    });
+
+    it('returns subscriptionDisabled: false when no subscriptionDisabledEpoch is in the cache', () => {
+      const token = 'sub-not-disabled-token';
+      writeRateLimit(token, {
+        'anthropic-ratelimit-unified-5h-status': 'allowed',
+        'anthropic-ratelimit-unified-5h-reset': '2000100',
+        'anthropic-ratelimit-unified-5h-utilization': '0.1',
+        'anthropic-ratelimit-unified-7d-status': 'allowed',
+        'anthropic-ratelimit-unified-7d-reset': '2000200',
+        'anthropic-ratelimit-unified-7d-utilization': '0.1',
+      });
+      const snapshot = readRateLimit(token);
+      expect(snapshot?.subscriptionDisabled).toBe(false);
     });
   });
 });

--- a/src/adapter/proxy/RateLimitCache.ts
+++ b/src/adapter/proxy/RateLimitCache.ts
@@ -21,6 +21,7 @@ export interface RateLimitSnapshot {
   modelWeeklyLimits: Record<string, ModelWeeklyLimit>;
   lastUpdatedEpoch: number;
   blockedUntilEpoch: number;
+  subscriptionDisabled: boolean;
 }
 
 export const PROXY_PORT = 8787;
@@ -166,6 +167,23 @@ export const writeModelRateLimit = (
   fs.writeFileSync(filePath, JSON.stringify(payload));
 };
 
+export const writeSubscriptionDisabled = (
+  token: string,
+  baseDir: string = cacheDir(),
+): void => {
+  const dir = baseDir;
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const filePath = path.join(dir, `${hashToken(token)}.json`);
+  const existing = readPayload(filePath);
+  const payload = {
+    ...existing,
+    subscriptionDisabledEpoch: Date.now() / 1000,
+  };
+  fs.writeFileSync(filePath, JSON.stringify(payload));
+};
+
 export const parseModelRateLimitsFromBody = (
   body: string,
 ): Record<string, ModelWeeklyLimit> => {
@@ -260,6 +278,10 @@ export const readRateLimit = (
     const storedBlockedUntil = parsed.blockedUntilEpoch;
     const blockedUntilEpoch =
       typeof storedBlockedUntil === 'number' ? storedBlockedUntil : 0;
+    const storedSubscriptionDisabledEpoch = parsed.subscriptionDisabledEpoch;
+    const subscriptionDisabled =
+      typeof storedSubscriptionDisabledEpoch === 'number' &&
+      storedSubscriptionDisabledEpoch > 0;
     return {
       fiveHourUtilization: num('anthropic-ratelimit-unified-5h-utilization'),
       fiveHourReset: num('anthropic-ratelimit-unified-5h-reset'),
@@ -279,6 +301,7 @@ export const readRateLimit = (
       },
       lastUpdatedEpoch,
       blockedUntilEpoch,
+      subscriptionDisabled,
     };
   } catch {
     return null;

--- a/src/adapter/proxy/proxyEntry.test.ts
+++ b/src/adapter/proxy/proxyEntry.test.ts
@@ -331,4 +331,28 @@ describe('startProxy', () => {
     expect(response.body).toBe('Upstream error');
     expect(writeModelRateLimitSpy).not.toHaveBeenCalled();
   });
+
+  it('should call writeSubscriptionDisabled when the response body contains the subscription-disabled message', async () => {
+    const writeSubscriptionDisabledSpy = jest
+      .spyOn(RateLimitCache, 'writeSubscriptionDisabled')
+      .mockImplementation(() => undefined);
+
+    upstreamHandler = (_request, response) => {
+      response.writeHead(403, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          error: {
+            message:
+              'Your organization has disabled Claude subscription access for Claude Code',
+          },
+        }),
+      );
+    };
+
+    await requestThroughProxy('POST', '/v1/messages', null);
+
+    expect(writeSubscriptionDisabledSpy).toHaveBeenCalledTimes(1);
+    expect(writeSubscriptionDisabledSpy).toHaveBeenCalledWith(TOKEN);
+    writeSubscriptionDisabledSpy.mockRestore();
+  });
 });

--- a/src/adapter/proxy/proxyEntry.ts
+++ b/src/adapter/proxy/proxyEntry.ts
@@ -6,6 +6,7 @@ import {
   parseModelRateLimitsFromBody,
   writeModelRateLimit,
   writeRateLimit,
+  writeSubscriptionDisabled,
 } from './RateLimitCache';
 import { ClaudeMessageResponseRepository } from '../../domain/usecases/adapter-interfaces/ClaudeMessageResponseRepository';
 import { parseClaudeMessageResponse } from './ClaudeMessageResponseParser';
@@ -72,6 +73,20 @@ const startProxy = (
               writeModelRateLimit(token, limits);
             } catch (error) {
               console.error('Failed to write model rate limit cache:', error);
+            }
+            if (
+              body.includes(
+                'Your organization has disabled Claude subscription access for Claude Code',
+              )
+            ) {
+              try {
+                writeSubscriptionDisabled(token);
+              } catch (error) {
+                console.error(
+                  'Failed to write subscription disabled cache:',
+                  error,
+                );
+              }
             }
             if (claudeMessageResponseRepository !== null) {
               try {

--- a/src/domain/usecases/LiveSessionOauthTokenSelectUseCase.test.ts
+++ b/src/domain/usecases/LiveSessionOauthTokenSelectUseCase.test.ts
@@ -22,10 +22,12 @@ const snapshot = (
 const candidate = (
   name: string,
   snapshotValue: OauthTokenWindowSnapshot | null,
+  subscriptionDisabled = false,
 ): OauthTokenCandidate => ({
   name,
   token: `fake-token-${name}`,
   snapshot: snapshotValue,
+  subscriptionDisabled,
 });
 
 const session = (name: string, sessionId: string): ClaudeLiveSession => ({
@@ -143,5 +145,24 @@ describe('LiveSessionOauthTokenSelectUseCase', () => {
 
     const lonely = result.metrics.find((m) => m.name === 'lonely');
     expect(lonely?.liveSessionCount).toBe(0);
+  });
+
+  it('excludes a subscription-disabled token even when it has zero live sessions', () => {
+    const result = useCase.run(
+      [
+        candidate('disabled', snapshot({}), true),
+        candidate('active', snapshot({}), false),
+      ],
+      [session('active', 'session-a')],
+      NOW,
+    );
+
+    expect(result.selected?.name).toBe('active');
+    const disabled = result.metrics.find((m) => m.name === 'disabled');
+    expect(disabled?.eligible).toBe(false);
+    expect(disabled?.liveSessionCount).toBe(0);
+    expect(disabled?.exclusionReason).toContain(
+      'organization has disabled Claude subscription access for Claude Code',
+    );
   });
 });

--- a/src/domain/usecases/OauthTokenSelectUseCase.test.ts
+++ b/src/domain/usecases/OauthTokenSelectUseCase.test.ts
@@ -21,10 +21,12 @@ const snapshot = (
 const candidate = (
   name: string,
   snapshotValue: OauthTokenWindowSnapshot | null,
+  subscriptionDisabled = false,
 ): OauthTokenCandidate => ({
   name,
   token: `fake-token-${name}`,
   snapshot: snapshotValue,
+  subscriptionDisabled,
 });
 
 describe('OauthTokenSelectUseCase', () => {
@@ -175,5 +177,22 @@ describe('OauthTokenSelectUseCase', () => {
     );
 
     expect(result.metrics.map((m) => m.name)).toEqual(['a', 'b']);
+  });
+
+  it('excludes a subscription-disabled token even when rate-limit windows are fully free', () => {
+    const result = useCase.run(
+      [
+        candidate('disabled', snapshot({}), true),
+        candidate('active', snapshot({}), false),
+      ],
+      NOW,
+    );
+
+    expect(result.selected?.name).toBe('active');
+    const disabled = result.metrics.find((m) => m.name === 'disabled');
+    expect(disabled?.eligible).toBe(false);
+    expect(disabled?.exclusionReason).toContain(
+      'organization has disabled Claude subscription access for Claude Code',
+    );
   });
 });

--- a/src/domain/usecases/OauthTokenSelectUseCase.ts
+++ b/src/domain/usecases/OauthTokenSelectUseCase.ts
@@ -9,6 +9,7 @@ export type OauthTokenCandidate = {
   name: string;
   token: string;
   snapshot: OauthTokenWindowSnapshot | null;
+  subscriptionDisabled: boolean;
 };
 
 export type OauthTokenCandidateMetrics = {
@@ -75,6 +76,7 @@ export class OauthTokenSelectUseCase {
     );
 
     const exclusionReason = this.exclusionReason(
+      candidate.subscriptionDisabled,
       fiveHourFreeRatio,
       sevenDayFreeRatio,
     );
@@ -90,9 +92,13 @@ export class OauthTokenSelectUseCase {
   };
 
   private exclusionReason = (
+    subscriptionDisabled: boolean,
     fiveHourFreeRatio: number,
     sevenDayFreeRatio: number,
   ): string | null => {
+    if (subscriptionDisabled) {
+      return 'organization has disabled Claude subscription access for Claude Code';
+    }
     if (fiveHourFreeRatio < FIVE_HOUR_MIN_FREE_RATIO) {
       return `5h window only ${this.toPercent(fiveHourFreeRatio)}% free (requires >= ${this.toPercent(FIVE_HOUR_MIN_FREE_RATIO)}%)`;
     }


### PR DESCRIPTION
From: :robot: HS Implement AI Agent

## Summary

When an organization disables Claude subscription access for Claude Code, the API returns an error response containing the message "Your organization has disabled Claude subscription access for Claude Code". Previously the token selection logic would still pick such a token (it has zero live sessions and full rate-limit headroom), causing every new session to fail at the first API call.

This PR makes the proxy detect that error in response bodies, persists a `subscriptionDisabledEpoch` flag to the per-token rate-limit cache file, and extends token selection to exclude tokens flagged as subscription-disabled.

## Changes

- `RateLimitCache.ts`: add `subscriptionDisabled` to `RateLimitSnapshot`; add `writeSubscriptionDisabled()` function
- `proxyEntry.ts`: detect the subscription-disabled error substring in response bodies and call `writeSubscriptionDisabled()`
- `OauthTokenSelectUseCase.ts`: add `subscriptionDisabled: boolean` to `OauthTokenCandidate`; check it first in `exclusionReason()`
- `OauthTokenSelectHandler.ts` / `LiveSessionOauthTokenSelectHandler.ts`: pass `subscriptionDisabled` when building candidate lists
- All test files: updated `candidate()` helpers; added new tests for the subscription-disabled exclusion path

Closes #983