### PR TITLE
feat: notify silent live tmux sessions with self-check prompts

### DIFF
--- a/src/adapter/entry-points/handlers/HandleScheduledEventUseCaseHandler.ts
+++ b/src/adapter/entry-points/handlers/HandleScheduledEventUseCaseHandler.ts
@@ -9,6 +9,7 @@ import { writeTokenStatus } from './tokenStatusWriter';
 import { writeInTmuxByHumanData } from './inTmuxByHumanDataWriter';
 import { reconcileInTmuxByHumanSessions } from './inTmuxByHumanSessionReconciler';
 import { cleanStaleTmuxSessions } from './staleTmuxSessionCleaner';
+import { notifySilentTmuxSessions } from './notifySilentTmuxSessions';
 import { writeRotationOrderFile } from './rotationOrderFileWriter';
 import {
   fetchProjectReadme,
@@ -87,6 +88,7 @@ export class HandleScheduledEventUseCaseHandler {
       inTmuxConsoleToken?: string;
       inTmuxProjectOrder?: string[];
       inTmuxLauncherCommand?: string;
+      sessionOutputRootDirectory?: string;
       credentials: {
         manager: {
           github: {
@@ -521,6 +523,28 @@ export class HandleScheduledEventUseCaseHandler {
       } catch (error) {
         console.error(
           `Failed to clean stale tmux sessions: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+
+      try {
+        const sessionOutputRootDirectory =
+          mergedInput.sessionOutputRootDirectory ??
+          process.env.TDPM_SESSION_OUTPUT_ROOT_DIRECTORY ??
+          null;
+        await notifySilentTmuxSessions({
+          project: result.project,
+          allowCacheMinutes: mergedInput.allowIssueCacheMinutes,
+          issueRepository,
+          localCommandRunner: nodeLocalCommandRunner,
+          cacheRepository: localStorageCacheRepository,
+          sessionOutputRootDirectory,
+          now: inTmuxNow,
+        });
+      } catch (error) {
+        console.error(
+          `Failed to notify silent tmux sessions: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );

--- a/src/adapter/entry-points/handlers/notifySilentTmuxSessions.test.ts
+++ b/src/adapter/entry-points/handlers/notifySilentTmuxSessions.test.ts
@@ -1,0 +1,199 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Issue } from '../../../domain/entities/Issue';
+import { Project } from '../../../domain/entities/Project';
+import { LocalCommandRunner } from '../../../domain/usecases/adapter-interfaces/LocalCommandRunner';
+import { IssueRepository } from '../../../domain/usecases/adapter-interfaces/IssueRepository';
+import { IN_TMUX_STATUS_NAME } from '../../../domain/entities/WorkflowStatus';
+import { LocalStorageCacheRepository } from '../../repositories/LocalStorageCacheRepository';
+import { LocalStorageRepository } from '../../repositories/LocalStorageRepository';
+import { notifySilentTmuxSessions } from './notifySilentTmuxSessions';
+
+const NOW = new Date('2026-06-26T00:00:00.000Z');
+const NOW_EPOCH_SECONDS = Math.floor(NOW.getTime() / 1000);
+const ALLOW_CACHE_MINUTES = 10;
+
+const makeProject = (): Project => ({
+  id: 'project-1',
+  url: 'https://github.com/users/user/projects/1',
+  databaseId: 1,
+  name: 'Test Project',
+  status: {
+    name: 'Status',
+    fieldId: 'field-1',
+    statuses: [],
+  },
+  nextActionDate: null,
+  nextActionHour: null,
+  story: null,
+  remainingEstimationMinutes: null,
+  dependedIssueUrlSeparatedByComma: null,
+  completionDate50PercentConfidence: null,
+});
+
+const makeIssue = (overrides: Partial<Issue> = {}): Issue => ({
+  nameWithOwner: 'demo/repo',
+  number: 1,
+  title: 'Issue 1',
+  state: 'OPEN',
+  status: IN_TMUX_STATUS_NAME,
+  story: null,
+  nextActionDate: null,
+  nextActionHour: null,
+  estimationMinutes: null,
+  dependedIssueUrls: [],
+  completionDate50PercentConfidence: null,
+  url: 'https://github.com/demo/repo/issues/1',
+  assignees: [],
+  labels: [],
+  org: 'demo',
+  repo: 'repo',
+  body: '',
+  itemId: 'item-1',
+  isPr: false,
+  isInProgress: false,
+  isClosed: false,
+  createdAt: new Date(),
+  author: '',
+  closingIssueReferenceUrls: [],
+  ...overrides,
+});
+
+type Mocked<T> = jest.Mocked<T> & jest.MockedObject<T>;
+
+const createMockRunner = (): Mocked<LocalCommandRunner> => ({
+  runCommand: jest.fn().mockResolvedValue({
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+  }),
+});
+
+const createMockIssueRepository = (
+  issues: Issue[],
+): Pick<IssueRepository, 'getAllOpened'> => ({
+  getAllOpened: jest.fn().mockResolvedValue(issues),
+});
+
+describe('notifySilentTmuxSessions', () => {
+  let outputDirectory: string;
+  let cacheDirectory: string;
+
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'silent-output-'));
+    cacheDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'silent-cache-'));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fs.rmSync(outputDirectory, { force: true, recursive: true });
+    fs.rmSync(cacheDirectory, { force: true, recursive: true });
+  });
+
+  const writeSilentOutputFile = (sessionName: string): void => {
+    const fileName = sessionName.replace(/\//g, '_');
+    const filePath = path.join(outputDirectory, fileName);
+    fs.writeFileSync(filePath, 'output', 'utf8');
+    const silentEpoch = NOW_EPOCH_SECONDS - 11 * 60;
+    fs.utimesSync(filePath, silentEpoch, silentEpoch);
+  };
+
+  const makeCacheRepository = (): LocalStorageCacheRepository =>
+    new LocalStorageCacheRepository(
+      new LocalStorageRepository(),
+      cacheDirectory,
+    );
+
+  it('sends a self-check notification to a silent monitored live session', async () => {
+    const sessionName = 'https_//github_com/demo/repo/issues/1';
+    writeSilentOutputFile(sessionName);
+    const runner = createMockRunner();
+    runner.runCommand.mockImplementation(async (program, args) => {
+      if (program === 'tmux' && args[0] === 'list-sessions') {
+        return { stdout: `${sessionName}\n`, stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    await notifySilentTmuxSessions({
+      project: makeProject(),
+      allowCacheMinutes: ALLOW_CACHE_MINUTES,
+      issueRepository: createMockIssueRepository([makeIssue()]),
+      localCommandRunner: runner,
+      cacheRepository: makeCacheRepository(),
+      sessionOutputRootDirectory: outputDirectory,
+      now: NOW,
+    });
+
+    const sendCall = runner.runCommand.mock.calls.find(
+      (call) => call[0] === 'tmux' && call[1][0] === 'send-keys',
+    );
+    expect(sendCall?.[1][2]).toBe(sessionName);
+  });
+
+  it('does nothing when the session output root directory is not configured', async () => {
+    const sessionName = 'https_//github_com/demo/repo/issues/1';
+    writeSilentOutputFile(sessionName);
+    const runner = createMockRunner();
+
+    await notifySilentTmuxSessions({
+      project: makeProject(),
+      allowCacheMinutes: ALLOW_CACHE_MINUTES,
+      issueRepository: createMockIssueRepository([makeIssue()]),
+      localCommandRunner: runner,
+      cacheRepository: makeCacheRepository(),
+      sessionOutputRootDirectory: null,
+      now: NOW,
+    });
+
+    expect(runner.runCommand.mock.calls).toHaveLength(0);
+  });
+
+  it('does not re-notify the same silent session on the next cycle within cooldown', async () => {
+    const sessionName = 'https_//github_com/demo/repo/issues/1';
+    writeSilentOutputFile(sessionName);
+    const runner = createMockRunner();
+    runner.runCommand.mockImplementation(async (program, args) => {
+      if (program === 'tmux' && args[0] === 'list-sessions') {
+        return { stdout: `${sessionName}\n`, stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    const cacheRepository = makeCacheRepository();
+
+    await notifySilentTmuxSessions({
+      project: makeProject(),
+      allowCacheMinutes: ALLOW_CACHE_MINUTES,
+      issueRepository: createMockIssueRepository([makeIssue()]),
+      localCommandRunner: runner,
+      cacheRepository,
+      sessionOutputRootDirectory: outputDirectory,
+      now: NOW,
+    });
+
+    const secondRunner = createMockRunner();
+    secondRunner.runCommand.mockImplementation(async (program, args) => {
+      if (program === 'tmux' && args[0] === 'list-sessions') {
+        return { stdout: `${sessionName}\n`, stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    await notifySilentTmuxSessions({
+      project: makeProject(),
+      allowCacheMinutes: ALLOW_CACHE_MINUTES,
+      issueRepository: createMockIssueRepository([makeIssue()]),
+      localCommandRunner: secondRunner,
+      cacheRepository,
+      sessionOutputRootDirectory: outputDirectory,
+      now: new Date(NOW.getTime() + 60 * 1000),
+    });
+
+    const secondSendCall = secondRunner.runCommand.mock.calls.find(
+      (call) => call[0] === 'tmux' && call[1][0] === 'send-keys',
+    );
+    expect(secondSendCall).toBeUndefined();
+  });
+});

--- a/src/adapter/entry-points/handlers/notifySilentTmuxSessions.ts
+++ b/src/adapter/entry-points/handlers/notifySilentTmuxSessions.ts
@@ -1,0 +1,60 @@
+import { Project } from '../../../domain/entities/Project';
+import { LocalCommandRunner } from '../../../domain/usecases/adapter-interfaces/LocalCommandRunner';
+import { IssueRepository } from '../../../domain/usecases/adapter-interfaces/IssueRepository';
+import {
+  NotifySilentLiveSessionsUseCase,
+  DEFAULT_EXCLUDED_STATUS,
+  DEFAULT_SILENT_THRESHOLD_SECONDS,
+  DEFAULT_NOTIFICATION_COOLDOWN_SECONDS,
+} from '../../../domain/usecases/NotifySilentLiveSessionsUseCase';
+import { NodeTmuxSessionRepository } from '../../repositories/NodeTmuxSessionRepository';
+import { FileSystemSessionOutputActivityRepository } from '../../repositories/FileSystemSessionOutputActivityRepository';
+import { TmuxSilentSessionNotificationRepository } from '../../repositories/TmuxSilentSessionNotificationRepository';
+import { LocalStorageCacheRepository } from '../../repositories/LocalStorageCacheRepository';
+
+export type NotifySilentTmuxSessionsParams = {
+  project: Project;
+  allowCacheMinutes: number;
+  issueRepository: Pick<IssueRepository, 'getAllOpened'>;
+  localCommandRunner: LocalCommandRunner;
+  cacheRepository: Pick<LocalStorageCacheRepository, 'getLatest' | 'set'>;
+  sessionOutputRootDirectory: string | null;
+  now: Date;
+};
+
+export const notifySilentTmuxSessions = async (
+  params: NotifySilentTmuxSessionsParams,
+): Promise<void> => {
+  const {
+    project,
+    allowCacheMinutes,
+    issueRepository,
+    localCommandRunner,
+    cacheRepository,
+    sessionOutputRootDirectory,
+    now,
+  } = params;
+  if (sessionOutputRootDirectory === null) {
+    console.log(
+      'Silent live session notification skipped: session output root directory is not configured.',
+    );
+    return;
+  }
+  const useCase = new NotifySilentLiveSessionsUseCase(
+    issueRepository,
+    new NodeTmuxSessionRepository(localCommandRunner),
+    new FileSystemSessionOutputActivityRepository(sessionOutputRootDirectory),
+    new TmuxSilentSessionNotificationRepository(
+      localCommandRunner,
+      cacheRepository,
+    ),
+  );
+  await useCase.run({
+    project,
+    allowCacheMinutes,
+    excludedStatus: DEFAULT_EXCLUDED_STATUS,
+    silentThresholdSeconds: DEFAULT_SILENT_THRESHOLD_SECONDS,
+    cooldownSeconds: DEFAULT_NOTIFICATION_COOLDOWN_SECONDS,
+    now,
+  });
+};

--- a/src/adapter/repositories/FileSystemSessionOutputActivityRepository.test.ts
+++ b/src/adapter/repositories/FileSystemSessionOutputActivityRepository.test.ts
@@ -1,0 +1,82 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FileSystemSessionOutputActivityRepository } from './FileSystemSessionOutputActivityRepository';
+
+describe('FileSystemSessionOutputActivityRepository', () => {
+  let rootDirectory: string;
+
+  beforeEach(() => {
+    rootDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'session-output-activity-'),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDirectory, { force: true, recursive: true });
+  });
+
+  const writeOutputFileWithMtime = (
+    sessionName: string,
+    epochSeconds: number,
+  ): void => {
+    const fileName = sessionName.replace(/\//g, '_');
+    const filePath = path.join(rootDirectory, fileName);
+    fs.writeFileSync(filePath, 'output', 'utf8');
+    fs.utimesSync(filePath, epochSeconds, epochSeconds);
+  };
+
+  it('returns the latest output epoch derived from each session output file mtime', async () => {
+    const sessionName = 'https_//github_com/owner/repo/issues/9';
+    writeOutputFileWithMtime(sessionName, 1700000000);
+    const repository = new FileSystemSessionOutputActivityRepository(
+      rootDirectory,
+    );
+
+    const result = await repository.listSessionOutputActivities([sessionName]);
+
+    expect(result).toEqual([
+      { sessionName, lastOutputEpochSeconds: 1700000000 },
+    ]);
+  });
+
+  it('omits sessions that have no output file', async () => {
+    const presentSessionName = 'https_//github_com/owner/repo/issues/9';
+    const missingSessionName = 'https_//github_com/owner/repo/issues/10';
+    writeOutputFileWithMtime(presentSessionName, 1700000000);
+    const repository = new FileSystemSessionOutputActivityRepository(
+      rootDirectory,
+    );
+
+    const result = await repository.listSessionOutputActivities([
+      presentSessionName,
+      missingSessionName,
+    ]);
+
+    expect(result).toEqual([
+      { sessionName: presentSessionName, lastOutputEpochSeconds: 1700000000 },
+    ]);
+  });
+
+  it('returns an empty list when the root directory does not exist', async () => {
+    const repository = new FileSystemSessionOutputActivityRepository(
+      path.join(rootDirectory, 'does-not-exist'),
+    );
+
+    const result = await repository.listSessionOutputActivities([
+      'https_//github_com/owner/repo/issues/9',
+    ]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty list when no session names are requested', async () => {
+    const repository = new FileSystemSessionOutputActivityRepository(
+      rootDirectory,
+    );
+
+    const result = await repository.listSessionOutputActivities([]);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/adapter/repositories/FileSystemSessionOutputActivityRepository.ts
+++ b/src/adapter/repositories/FileSystemSessionOutputActivityRepository.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { LiveSessionOutputActivity } from '../../domain/entities/LiveSessionOutputActivity';
+import { SessionOutputActivityRepository } from '../../domain/usecases/adapter-interfaces/SessionOutputActivityRepository';
+
+export class FileSystemSessionOutputActivityRepository implements SessionOutputActivityRepository {
+  constructor(private readonly rootDirectory: string) {}
+
+  listSessionOutputActivities = async (
+    sessionNames: string[],
+  ): Promise<LiveSessionOutputActivity[]> => {
+    const activities: LiveSessionOutputActivity[] = [];
+    for (const sessionName of sessionNames) {
+      const lastOutputEpochSeconds =
+        this.readLastOutputEpochSeconds(sessionName);
+      if (lastOutputEpochSeconds !== null) {
+        activities.push({ sessionName, lastOutputEpochSeconds });
+      }
+    }
+    return activities;
+  };
+
+  private readLastOutputEpochSeconds = (sessionName: string): number | null => {
+    const filePath = path.join(
+      this.rootDirectory,
+      this.toOutputFileName(sessionName),
+    );
+    let stats: fs.Stats;
+    try {
+      stats = fs.statSync(filePath);
+    } catch {
+      return null;
+    }
+    if (!stats.isFile()) {
+      return null;
+    }
+    return Math.floor(stats.mtimeMs / 1000);
+  };
+
+  private toOutputFileName = (sessionName: string): string =>
+    sessionName.replace(/\//g, '_');
+}

--- a/src/adapter/repositories/TmuxSilentSessionNotificationRepository.test.ts
+++ b/src/adapter/repositories/TmuxSilentSessionNotificationRepository.test.ts
@@ -1,0 +1,153 @@
+import { LocalCommandRunner } from '../../domain/usecases/adapter-interfaces/LocalCommandRunner';
+import { LocalStorageCacheRepository } from './LocalStorageCacheRepository';
+import { TmuxSilentSessionNotificationRepository } from './TmuxSilentSessionNotificationRepository';
+
+type Mocked<T> = jest.Mocked<T> & jest.MockedObject<T>;
+
+const createMockRunner = (): Mocked<LocalCommandRunner> => ({
+  runCommand: jest.fn().mockResolvedValue({
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+  }),
+});
+
+const createMockCacheRepository = (): Mocked<
+  Pick<LocalStorageCacheRepository, 'getLatest' | 'set'>
+> => ({
+  getLatest: jest.fn().mockResolvedValue(null),
+  set: jest.fn().mockResolvedValue(undefined),
+});
+
+describe('TmuxSilentSessionNotificationRepository', () => {
+  describe('sendSelfCheckNotification', () => {
+    it('sends the message literally then submits it with Enter', async () => {
+      const runner = createMockRunner();
+      const cache = createMockCacheRepository();
+      const repository = new TmuxSilentSessionNotificationRepository(
+        runner,
+        cache,
+      );
+
+      await repository.sendSelfCheckNotification(
+        'https_//github_com/owner/repo/issues/9',
+        'self check message',
+      );
+
+      expect(runner.runCommand.mock.calls[0]).toEqual([
+        'tmux',
+        [
+          'send-keys',
+          '-t',
+          'https_//github_com/owner/repo/issues/9',
+          '-l',
+          'self check message',
+        ],
+      ]);
+      expect(runner.runCommand.mock.calls[1]).toEqual([
+        'tmux',
+        ['send-keys', '-t', 'https_//github_com/owner/repo/issues/9', 'Enter'],
+      ]);
+    });
+
+    it('throws when sending the message literally fails', async () => {
+      const runner = createMockRunner();
+      runner.runCommand.mockResolvedValueOnce({
+        stdout: '',
+        stderr: "can't find session",
+        exitCode: 1,
+      });
+      const cache = createMockCacheRepository();
+      const repository = new TmuxSilentSessionNotificationRepository(
+        runner,
+        cache,
+      );
+
+      await expect(
+        repository.sendSelfCheckNotification('missing_session', 'message'),
+      ).rejects.toThrow(
+        'Failed to send notification to tmux session "missing_session"',
+      );
+    });
+  });
+
+  describe('getLastNotifiedEpochSeconds', () => {
+    it('returns the cached epoch seconds for a session', async () => {
+      const runner = createMockRunner();
+      const cache = createMockCacheRepository();
+      cache.getLatest.mockResolvedValue({
+        value: { epochSeconds: 1700000000 },
+        timestamp: new Date(),
+      });
+      const repository = new TmuxSilentSessionNotificationRepository(
+        runner,
+        cache,
+      );
+
+      const result = await repository.getLastNotifiedEpochSeconds(
+        'https_//github_com/owner/repo/issues/9',
+      );
+
+      expect(result).toBe(1700000000);
+      expect(cache.getLatest).toHaveBeenCalledWith(
+        'silent-session-notification/https___github_com_owner_repo_issues_9',
+      );
+    });
+
+    it('returns null when no cache entry exists', async () => {
+      const runner = createMockRunner();
+      const cache = createMockCacheRepository();
+      cache.getLatest.mockResolvedValue(null);
+      const repository = new TmuxSilentSessionNotificationRepository(
+        runner,
+        cache,
+      );
+
+      const result = await repository.getLastNotifiedEpochSeconds(
+        'https_//github_com/owner/repo/issues/9',
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the cached value has no numeric epoch', async () => {
+      const runner = createMockRunner();
+      const cache = createMockCacheRepository();
+      cache.getLatest.mockResolvedValue({
+        value: {},
+        timestamp: new Date(),
+      });
+      const repository = new TmuxSilentSessionNotificationRepository(
+        runner,
+        cache,
+      );
+
+      const result = await repository.getLastNotifiedEpochSeconds(
+        'https_//github_com/owner/repo/issues/9',
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setLastNotifiedEpochSeconds', () => {
+    it('persists the epoch seconds keyed by the sanitized session name', async () => {
+      const runner = createMockRunner();
+      const cache = createMockCacheRepository();
+      const repository = new TmuxSilentSessionNotificationRepository(
+        runner,
+        cache,
+      );
+
+      await repository.setLastNotifiedEpochSeconds(
+        'https_//github_com/owner/repo/issues/9',
+        1700000000,
+      );
+
+      expect(cache.set).toHaveBeenCalledWith(
+        'silent-session-notification/https___github_com_owner_repo_issues_9',
+        { epochSeconds: 1700000000 },
+      );
+    });
+  });
+});

--- a/src/adapter/repositories/TmuxSilentSessionNotificationRepository.ts
+++ b/src/adapter/repositories/TmuxSilentSessionNotificationRepository.ts
@@ -1,0 +1,83 @@
+import { SilentSessionNotificationRepository } from '../../domain/usecases/adapter-interfaces/SilentSessionNotificationRepository';
+import { LocalCommandRunner } from '../../domain/usecases/adapter-interfaces/LocalCommandRunner';
+import { LocalStorageCacheRepository } from './LocalStorageCacheRepository';
+
+const CACHE_KEY_PREFIX = 'silent-session-notification';
+
+const readEpochSeconds = (value: object): number | null => {
+  if (!('epochSeconds' in value)) {
+    return null;
+  }
+  const candidate = value.epochSeconds;
+  if (typeof candidate !== 'number') {
+    return null;
+  }
+  return candidate;
+};
+
+export class TmuxSilentSessionNotificationRepository implements SilentSessionNotificationRepository {
+  constructor(
+    private readonly localCommandRunner: LocalCommandRunner,
+    private readonly cacheRepository: Pick<
+      LocalStorageCacheRepository,
+      'getLatest' | 'set'
+    >,
+  ) {}
+
+  getLastNotifiedEpochSeconds = async (
+    sessionName: string,
+  ): Promise<number | null> => {
+    const cached = await this.cacheRepository.getLatest(
+      this.toCacheKey(sessionName),
+    );
+    if (cached === null) {
+      return null;
+    }
+    return readEpochSeconds(cached.value);
+  };
+
+  setLastNotifiedEpochSeconds = async (
+    sessionName: string,
+    epochSeconds: number,
+  ): Promise<void> => {
+    await this.cacheRepository.set(this.toCacheKey(sessionName), {
+      epochSeconds,
+    });
+  };
+
+  sendSelfCheckNotification = async (
+    sessionName: string,
+    message: string,
+  ): Promise<void> => {
+    const literalResult = await this.localCommandRunner.runCommand('tmux', [
+      'send-keys',
+      '-t',
+      sessionName,
+      '-l',
+      message,
+    ]);
+    if (literalResult.exitCode !== 0) {
+      throw new Error(
+        `Failed to send notification to tmux session "${sessionName}": exit code ${literalResult.exitCode}${
+          literalResult.stderr ? `: ${literalResult.stderr}` : ''
+        }`,
+      );
+    }
+    const submitResult = await this.localCommandRunner.runCommand('tmux', [
+      'send-keys',
+      '-t',
+      sessionName,
+      'Enter',
+    ]);
+    if (submitResult.exitCode !== 0) {
+      throw new Error(
+        `Failed to send notification to tmux session "${sessionName}": exit code ${submitResult.exitCode}${
+          submitResult.stderr ? `: ${submitResult.stderr}` : ''
+        }`,
+      );
+    }
+  };
+
+  private toCacheKey = (sessionName: string): string =>
+    `${CACHE_KEY_PREFIX}/${sessionName.replace(/\//g, '_')}`;
+}

--- a/src/domain/entities/LiveSessionOutputActivity.ts
+++ b/src/domain/entities/LiveSessionOutputActivity.ts
@@ -1,0 +1,4 @@
+export type LiveSessionOutputActivity = {
+  sessionName: string;
+  lastOutputEpochSeconds: number;
+};

--- a/src/domain/usecases/NotifySilentLiveSessionsUseCase.test.ts
+++ b/src/domain/usecases/NotifySilentLiveSessionsUseCase.test.ts
@@ -1,0 +1,368 @@
+import {
+  NotifySilentLiveSessionsUseCase,
+  DEFAULT_EXCLUDED_STATUS,
+  DEFAULT_SILENT_THRESHOLD_SECONDS,
+  DEFAULT_NOTIFICATION_COOLDOWN_SECONDS,
+  SELF_CHECK_NOTIFICATION_MESSAGE,
+} from './NotifySilentLiveSessionsUseCase';
+import { IssueRepository } from './adapter-interfaces/IssueRepository';
+import { TmuxSessionRepository } from './adapter-interfaces/TmuxSessionRepository';
+import { SessionOutputActivityRepository } from './adapter-interfaces/SessionOutputActivityRepository';
+import { SilentSessionNotificationRepository } from './adapter-interfaces/SilentSessionNotificationRepository';
+import { toTmuxSessionName } from './intmux/InTmuxByHumanSessionReconcileUseCase';
+import { Issue } from '../entities/Issue';
+import { Project } from '../entities/Project';
+import { IN_TMUX_STATUS_NAME } from '../entities/WorkflowStatus';
+
+type Mocked<T> = jest.Mocked<T> & jest.MockedObject<T>;
+
+const createMockProject = (): Project => ({
+  id: 'project-1',
+  url: 'https://github.com/users/user/projects/1',
+  databaseId: 1,
+  name: 'Test Project',
+  status: {
+    name: 'Status',
+    fieldId: 'field-1',
+    statuses: [],
+  },
+  nextActionDate: null,
+  nextActionHour: null,
+  story: null,
+  remainingEstimationMinutes: null,
+  dependedIssueUrlSeparatedByComma: null,
+  completionDate50PercentConfidence: null,
+});
+
+let issueCounter = 0;
+const createMockIssue = (overrides: Partial<Issue> = {}): Issue => {
+  issueCounter += 1;
+  return {
+    nameWithOwner: 'user/repo',
+    number: issueCounter,
+    title: `Test Issue ${issueCounter}`,
+    state: 'OPEN',
+    status: IN_TMUX_STATUS_NAME,
+    story: null,
+    nextActionDate: null,
+    nextActionHour: null,
+    estimationMinutes: null,
+    dependedIssueUrls: [],
+    completionDate50PercentConfidence: null,
+    url: `https://github.com/user/repo/issues/${issueCounter}`,
+    assignees: [],
+    labels: [],
+    org: 'user',
+    repo: 'repo',
+    body: '',
+    itemId: `item-${issueCounter}`,
+    isPr: false,
+    isInProgress: false,
+    isClosed: false,
+    createdAt: new Date(),
+    author: 'testuser',
+    closingIssueReferenceUrls: [],
+    ...overrides,
+  };
+};
+
+describe('NotifySilentLiveSessionsUseCase', () => {
+  let useCase: NotifySilentLiveSessionsUseCase;
+  let mockIssueRepository: Mocked<Pick<IssueRepository, 'getAllOpened'>>;
+  let mockTmuxSessionRepository: Mocked<
+    Pick<TmuxSessionRepository, 'listLiveSessionNames'>
+  >;
+  let mockSessionOutputActivityRepository: Mocked<SessionOutputActivityRepository>;
+  let mockNotificationRepository: Mocked<SilentSessionNotificationRepository>;
+  let mockProject: Project;
+  const now = new Date('2026-06-26T00:00:00Z');
+  const nowEpochSeconds = Math.floor(now.getTime() / 1000);
+  const allowCacheMinutes = 10;
+
+  const runParams = (): {
+    project: Project;
+    allowCacheMinutes: number;
+    excludedStatus: string;
+    silentThresholdSeconds: number;
+    cooldownSeconds: number;
+    now: Date;
+  } => ({
+    project: mockProject,
+    allowCacheMinutes,
+    excludedStatus: DEFAULT_EXCLUDED_STATUS,
+    silentThresholdSeconds: DEFAULT_SILENT_THRESHOLD_SECONDS,
+    cooldownSeconds: DEFAULT_NOTIFICATION_COOLDOWN_SECONDS,
+    now,
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    mockProject = createMockProject();
+    mockIssueRepository = {
+      getAllOpened: jest.fn().mockResolvedValue([]),
+    };
+    mockTmuxSessionRepository = {
+      listLiveSessionNames: jest.fn().mockResolvedValue([]),
+    };
+    mockSessionOutputActivityRepository = {
+      listSessionOutputActivities: jest.fn().mockResolvedValue([]),
+    };
+    mockNotificationRepository = {
+      getLastNotifiedEpochSeconds: jest.fn().mockResolvedValue(null),
+      setLastNotifiedEpochSeconds: jest.fn().mockResolvedValue(undefined),
+      sendSelfCheckNotification: jest.fn().mockResolvedValue(undefined),
+    };
+    useCase = new NotifySilentLiveSessionsUseCase(
+      mockIssueRepository,
+      mockTmuxSessionRepository,
+      mockSessionOutputActivityRepository,
+      mockNotificationRepository,
+    );
+  });
+
+  it('exposes the excluded status, default threshold and cooldown as named constants', () => {
+    expect(DEFAULT_EXCLUDED_STATUS).toBe('In Tmux by human');
+    expect(DEFAULT_EXCLUDED_STATUS).toBe(IN_TMUX_STATUS_NAME);
+    expect(DEFAULT_SILENT_THRESHOLD_SECONDS).toBe(600);
+    expect(DEFAULT_NOTIFICATION_COOLDOWN_SECONDS).toBe(30 * 60);
+  });
+
+  it('notifies a live monitored session that has been silent at least the threshold', async () => {
+    const issue = createMockIssue({ status: IN_TMUX_STATUS_NAME });
+    const sessionName = toTmuxSessionName(issue.url);
+    mockIssueRepository.getAllOpened.mockResolvedValue([issue]);
+    mockTmuxSessionRepository.listLiveSessionNames.mockResolvedValue([
+      sessionName,
+    ]);
+    mockSessionOutputActivityRepository.listSessionOutputActivities.mockResolvedValue(
+      [
+        {
+          sessionName,
+          lastOutputEpochSeconds:
+            nowEpochSeconds - DEFAULT_SILENT_THRESHOLD_SECONDS,
+        },
+      ],
+    );
+
+    await useCase.run(runParams());
+
+    expect(
+      mockNotificationRepository.sendSelfCheckNotification,
+    ).toHaveBeenCalledWith(sessionName, SELF_CHECK_NOTIFICATION_MESSAGE);
+    expect(
+      mockNotificationRepository.setLastNotifiedEpochSeconds,
+    ).toHaveBeenCalledWith(sessionName, nowEpochSeconds);
+  });
+
+  it('passes the monitored session names to the output activity repository', async () => {
+    const issue = createMockIssue({ status: IN_TMUX_STATUS_NAME });
+    const sessionName = toTmuxSessionName(issue.url);
+    mockIssueRepository.getAllOpened.mockResolvedValue([issue]);
+    mockTmuxSessionRepository.listLiveSessionNames.mockResolvedValue([
+      sessionName,
+    ]);
+
+    await useCase.run(runParams());
+
+    expect(
+      mockSessionOutputActivityRepository.listSessionOutputActivities,
+    ).toHaveBeenCalledWith([sessionName]);
+    expect(mockIssueRepository.getAllOpened).toHaveBeenCalledWith(
+      mockProject,
+      allowCacheMinutes,
+    );
+  });
+
+  it('does not notify a session that produced output within the threshold', async () => {
+    const issue = createMockIssue({ status: IN_TMUX_STATUS_NAME });
+    const sessionName = toTmuxSessionName(issue.url);
+    mockIssueRepository.getAllOpened.mockResolvedValue([issue]);
+    mockTmuxSessionRepository.listLiveSessionNames.mockResolvedValue([
+      sessionName,
+    ]);
+    mockSessionOutputActivityRepository.listSessionOutputActivities.mockResolvedValue(
+      [
+        {
+          sessionName,
+          lastOutputEpochSeconds:
+            nowEpochSeconds - DEFAULT_SILENT_THRESHOLD_SECONDS + 1,
+        },
+      ],
+    );
+
+    await useCase.run(runParams());
+
+    expect(
+      mockNotificationRepository.sendSelfCheckNotification,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not notify a live session that maps to no monitored issue', async () => {
+    mockIssueRepository.getAllOpened.mockResolvedValue([]);
+    mockTmuxSessionRepository.listLiveSessionNames.mockResolvedValue([
+      'orphan_session',
+    ]);
+    mockSessionOutputActivityRepository.listSessionOutputActivities.mockResolvedValue(
+      [],
+    );
+
+    await useCase.run(runParams());
+
+    expect(
+      mockSessionOutputActivityRepository.listSessionOutputActivities,
+    ).toHaveBeenCalledWith([]);
+    expect(
+      mockNotificationRepository.sendSelfCheckNotification,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not notify a monitored issue whose session is not live', async () => {
+    const issue = createMockIssue({ status: IN_TMUX_STATUS_NAME });
+    mockIssueRepository.getAllOpened.mockResolvedValue([issue]);
+    mockTmuxSessionRepository.listLiveSessionNames.mockResolvedValue([]);
+
+    await useCase.run(runParams());
+
+    expect(
+      mockSessionOutputActivityRepository.listSessionOutputActivities,
+    ).toHaveBeenCalledWith([]);
+    expect(
+      mockNotificationRepository.sendSelfCheckNotification,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not notify a live session whose issue status is not the excluded status', async () => {
+    const issue = createMockIssue({ status: 'In Progress' });
+    const sessionName = toTmuxSessionName(issue.url);
+    mockIssueRepository.getAllOpened.mockResolvedValue([issue]);
+    mockTmuxSessionRepository.listLiveSessionNames.mockResolvedValue([
+      sessionName,
+    ]);
+    mockSessionOutputActivityRepository.listSessionOutputActivities.mockResolvedValue(
+      [
+        {
+          sessionName,
+          lastOutputEpochSeconds:
+            nowEpochSeconds - DEFAULT_SILENT_THRESHOLD_SECONDS,
+        },
+      ],
+    );
+
+    await useCase.run(runParams());
+
+    expect(
+      mockSessionOutputActivityRepository.listSessionOutputActivities,
+    ).toHaveBeenCalledWith([]);
+    expect(
+      mockNotificationRepository.sendSelfCheckNotification,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not re-notify a session within the cooldown window', async () => {
+    const issue = createMockIssue({ status: IN_TMUX_STATUS_NAME });
+    const sessionName = toTmuxSessionName(issue.url);
+    mockIssueRepository.getAllOpened.mockResolvedValue([issue]);
+    mockTmuxSessionRepository.listLiveSessionNames.mockResolvedValue([
+      sessionName,
+    ]);
+    mockSessionOutputActivityRepository.listSessionOutputActivities.mockResolvedValue(
+      [
+        {
+          sessionName,
+          lastOutputEpochSeconds:
+            nowEpochSeconds - DEFAULT_SILENT_THRESHOLD_SECONDS,
+        },
+      ],
+    );
+    mockNotificationRepository.getLastNotifiedEpochSeconds.mockResolvedValue(
+      nowEpochSeconds - DEFAULT_NOTIFICATION_COOLDOWN_SECONDS + 1,
+    );
+
+    await useCase.run(runParams());
+
+    expect(
+      mockNotificationRepository.sendSelfCheckNotification,
+    ).not.toHaveBeenCalled();
+    expect(
+      mockNotificationRepository.setLastNotifiedEpochSeconds,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('re-notifies a session once the cooldown window has elapsed', async () => {
+    const issue = createMockIssue({ status: IN_TMUX_STATUS_NAME });
+    const sessionName = toTmuxSessionName(issue.url);
+    mockIssueRepository.getAllOpened.mockResolvedValue([issue]);
+    mockTmuxSessionRepository.listLiveSessionNames.mockResolvedValue([
+      sessionName,
+    ]);
+    mockSessionOutputActivityRepository.listSessionOutputActivities.mockResolvedValue(
+      [
+        {
+          sessionName,
+          lastOutputEpochSeconds:
+            nowEpochSeconds - DEFAULT_SILENT_THRESHOLD_SECONDS,
+        },
+      ],
+    );
+    mockNotificationRepository.getLastNotifiedEpochSeconds.mockResolvedValue(
+      nowEpochSeconds - DEFAULT_NOTIFICATION_COOLDOWN_SECONDS,
+    );
+
+    await useCase.run(runParams());
+
+    expect(
+      mockNotificationRepository.sendSelfCheckNotification,
+    ).toHaveBeenCalledWith(sessionName, SELF_CHECK_NOTIFICATION_MESSAGE);
+    expect(
+      mockNotificationRepository.setLastNotifiedEpochSeconds,
+    ).toHaveBeenCalledWith(sessionName, nowEpochSeconds);
+  });
+
+  it('does not notify a session that has no recorded output activity', async () => {
+    const issue = createMockIssue({ status: IN_TMUX_STATUS_NAME });
+    const sessionName = toTmuxSessionName(issue.url);
+    mockIssueRepository.getAllOpened.mockResolvedValue([issue]);
+    mockTmuxSessionRepository.listLiveSessionNames.mockResolvedValue([
+      sessionName,
+    ]);
+    mockSessionOutputActivityRepository.listSessionOutputActivities.mockResolvedValue(
+      [],
+    );
+
+    await useCase.run(runParams());
+
+    expect(
+      mockNotificationRepository.sendSelfCheckNotification,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('contains the three general self-check points in the notification message', () => {
+    expect(SELF_CHECK_NOTIFICATION_MESSAGE).toContain('1.');
+    expect(SELF_CHECK_NOTIFICATION_MESSAGE).toContain('2.');
+    expect(SELF_CHECK_NOTIFICATION_MESSAGE).toContain('3.');
+  });
+
+  it('does not suppress errors raised while sending a notification', async () => {
+    const issue = createMockIssue({ status: IN_TMUX_STATUS_NAME });
+    const sessionName = toTmuxSessionName(issue.url);
+    mockIssueRepository.getAllOpened.mockResolvedValue([issue]);
+    mockTmuxSessionRepository.listLiveSessionNames.mockResolvedValue([
+      sessionName,
+    ]);
+    mockSessionOutputActivityRepository.listSessionOutputActivities.mockResolvedValue(
+      [
+        {
+          sessionName,
+          lastOutputEpochSeconds:
+            nowEpochSeconds - DEFAULT_SILENT_THRESHOLD_SECONDS,
+        },
+      ],
+    );
+    mockNotificationRepository.sendSelfCheckNotification.mockRejectedValue(
+      new Error('send-keys failed'),
+    );
+
+    await expect(useCase.run(runParams())).rejects.toThrow('send-keys failed');
+  });
+});

--- a/src/domain/usecases/NotifySilentLiveSessionsUseCase.ts
+++ b/src/domain/usecases/NotifySilentLiveSessionsUseCase.ts
@@ -1,0 +1,134 @@
+import { Issue } from '../entities/Issue';
+import { Project } from '../entities/Project';
+import { IN_TMUX_STATUS_NAME } from '../entities/WorkflowStatus';
+import { IssueRepository } from './adapter-interfaces/IssueRepository';
+import { SessionOutputActivityRepository } from './adapter-interfaces/SessionOutputActivityRepository';
+import { SilentSessionNotificationRepository } from './adapter-interfaces/SilentSessionNotificationRepository';
+import { TmuxSessionRepository } from './adapter-interfaces/TmuxSessionRepository';
+import { toTmuxSessionName } from './intmux/InTmuxByHumanSessionReconcileUseCase';
+
+export const DEFAULT_EXCLUDED_STATUS = IN_TMUX_STATUS_NAME;
+export const DEFAULT_SILENT_THRESHOLD_SECONDS = 10 * 60;
+export const DEFAULT_NOTIFICATION_COOLDOWN_SECONDS = 30 * 60;
+
+export const SELF_CHECK_NOTIFICATION_MESSAGE = [
+  '出力が一定時間止まっています。次の3点を自己点検してください。',
+  '1. オーナーから受けた依頼がすべてセッションのタスクとして登録されているか、そしてその進め方が最速になっているか（独立作業の並列化・委譲・不要な直列化の排除）を再点検する。',
+  '2. 子プロセス・サブ作業が一定時間（5分）出力を出していないことを検知する監視が設定されているかを確認する。',
+  '3. オーナーへの呼び出し（確認・質問・判断依頼）が必要なのに行えていない状態になっていないかを確認し、必要なら呼び出す。',
+].join('\n');
+
+type NotifyCandidate = {
+  sessionName: string;
+  silentSeconds: number;
+};
+
+export class NotifySilentLiveSessionsUseCase {
+  constructor(
+    private readonly issueRepository: Pick<IssueRepository, 'getAllOpened'>,
+    private readonly tmuxSessionRepository: Pick<
+      TmuxSessionRepository,
+      'listLiveSessionNames'
+    >,
+    private readonly sessionOutputActivityRepository: SessionOutputActivityRepository,
+    private readonly notificationRepository: SilentSessionNotificationRepository,
+  ) {}
+
+  run = async (params: {
+    project: Project;
+    allowCacheMinutes: number;
+    excludedStatus: string;
+    silentThresholdSeconds: number;
+    cooldownSeconds: number;
+    now: Date;
+  }): Promise<void> => {
+    const liveSessionNames = new Set(
+      await this.tmuxSessionRepository.listLiveSessionNames(),
+    );
+    const openIssues = await this.issueRepository.getAllOpened(
+      params.project,
+      params.allowCacheMinutes,
+    );
+    const monitoredSessionNames = this.selectMonitoredSessionNames(
+      openIssues,
+      liveSessionNames,
+      params.excludedStatus,
+    );
+
+    const activities =
+      await this.sessionOutputActivityRepository.listSessionOutputActivities(
+        monitoredSessionNames,
+      );
+    const lastOutputBySessionName = new Map<string, number>();
+    for (const activity of activities) {
+      lastOutputBySessionName.set(
+        activity.sessionName,
+        activity.lastOutputEpochSeconds,
+      );
+    }
+
+    const nowEpochSeconds = Math.floor(params.now.getTime() / 1000);
+    const candidates: NotifyCandidate[] = [];
+    for (const sessionName of monitoredSessionNames) {
+      const lastOutputEpochSeconds = lastOutputBySessionName.get(sessionName);
+      if (lastOutputEpochSeconds === undefined) {
+        continue;
+      }
+      const silentSeconds = nowEpochSeconds - lastOutputEpochSeconds;
+      if (silentSeconds >= params.silentThresholdSeconds) {
+        candidates.push({ sessionName, silentSeconds });
+      }
+    }
+
+    console.log(
+      `Silent live session notification: ${candidates.length} candidate(s) of ${monitoredSessionNames.length} monitored session(s).`,
+    );
+
+    for (const candidate of candidates) {
+      const lastNotifiedEpochSeconds =
+        await this.notificationRepository.getLastNotifiedEpochSeconds(
+          candidate.sessionName,
+        );
+      if (
+        lastNotifiedEpochSeconds !== null &&
+        nowEpochSeconds - lastNotifiedEpochSeconds < params.cooldownSeconds
+      ) {
+        console.log(
+          `Skipping ${candidate.sessionName}: notified ${
+            nowEpochSeconds - lastNotifiedEpochSeconds
+          } seconds ago, within cooldown ${params.cooldownSeconds} seconds.`,
+        );
+        continue;
+      }
+      await this.notificationRepository.sendSelfCheckNotification(
+        candidate.sessionName,
+        SELF_CHECK_NOTIFICATION_MESSAGE,
+      );
+      await this.notificationRepository.setLastNotifiedEpochSeconds(
+        candidate.sessionName,
+        nowEpochSeconds,
+      );
+      console.log(
+        `Notified ${candidate.sessionName}: silent for ${candidate.silentSeconds} seconds (threshold ${params.silentThresholdSeconds} seconds).`,
+      );
+    }
+  };
+
+  private selectMonitoredSessionNames = (
+    openIssues: Issue[],
+    liveSessionNames: Set<string>,
+    excludedStatus: string,
+  ): string[] => {
+    const monitoredSessionNames: string[] = [];
+    for (const issue of openIssues) {
+      if (issue.status !== excludedStatus) {
+        continue;
+      }
+      const sessionName = toTmuxSessionName(issue.url);
+      if (liveSessionNames.has(sessionName)) {
+        monitoredSessionNames.push(sessionName);
+      }
+    }
+    return monitoredSessionNames;
+  };
+}

--- a/src/domain/usecases/adapter-interfaces/SessionOutputActivityRepository.ts
+++ b/src/domain/usecases/adapter-interfaces/SessionOutputActivityRepository.ts
@@ -1,0 +1,7 @@
+import { LiveSessionOutputActivity } from '../../entities/LiveSessionOutputActivity';
+
+export interface SessionOutputActivityRepository {
+  listSessionOutputActivities: (
+    sessionNames: string[],
+  ) => Promise<LiveSessionOutputActivity[]>;
+}

--- a/src/domain/usecases/adapter-interfaces/SilentSessionNotificationRepository.ts
+++ b/src/domain/usecases/adapter-interfaces/SilentSessionNotificationRepository.ts
@@ -1,0 +1,11 @@
+export interface SilentSessionNotificationRepository {
+  getLastNotifiedEpochSeconds: (sessionName: string) => Promise<number | null>;
+  setLastNotifiedEpochSeconds: (
+    sessionName: string,
+    epochSeconds: number,
+  ) => Promise<void>;
+  sendSelfCheckNotification: (
+    sessionName: string,
+    message: string,
+  ) => Promise<void>;
+}


### PR DESCRIPTION
## Summary

Adds scheduled monitoring that detects live tmux sessions whose standard output has been silent for a configurable period and sends a self-check notification into the affected session via `tmux send-keys`.

The silence signal is the last-modified time (mtime) of each live session's output file. A re-notification cooldown prevents repeated notifications while a session stays silent.

## Behavior

- The monitored set is the open issues whose project Status is the in-tmux-by-human status, mapped to tmux session names and intersected with the currently live sessions (reusing the existing `toTmuxSessionName` and live-session listing logic).
- For each monitored live session, the last output time is read from the mtime of its output file under a configurable root directory.
- A session silent for at least the threshold (default 600 seconds) receives a notification.
- Re-notification of the same session is suppressed by a cooldown (default 30 minutes) persisted in the existing cache mechanism.
- Wired into the scheduled event handler alongside the existing tmux session cleanup.

## Design

- The new domain use case `NotifySilentLiveSessionsUseCase` keeps pure logic: it takes the monitored session names, each session's last output epoch seconds, the current time, the silent threshold, and the cooldown, and instructs the repositories to notify silent sessions. No tmux or filesystem dependency lives in the domain layer.
- Adapters: a filesystem repository reads each session output file mtime (root directory injected from configuration or the `TDPM_SESSION_OUTPUT_ROOT_DIRECTORY` environment variable, never hardcoded), and a tmux repository sends the notification via `tmux send-keys` and persists the last-notified time in the cache.
- The notification carries three general self-check points in plain language.

## Configuration

- `sessionOutputRootDirectory` config field, falling back to the `TDPM_SESSION_OUTPUT_ROOT_DIRECTORY` environment variable. When neither is set, the monitoring step is a no-op.

## Tests

- Co-located `*.test.ts` for the domain use case, both adapters, and the schedule handler wiring, covering the threshold boundary, cooldown suppression, re-notification after cooldown, monitored-set selection, missing output files, and unconfigured root directory.
