### PR TITLE
fix(project-repository): remove project-metadata disk cache, keep immutable project ID cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,17 +350,16 @@ When `claudeCodeOauthTokenListJsonPath` is unset, no proxy is started and `aw` r
 - files:write
 - files:read
 
-## Project Metadata Cache
+## Project ID Cache
 
-The static GitHub Project metadata that `GraphqlProjectRepository` resolves — the project node ID (`fetchProjectId`) and the project's fields, single-select status options, and iteration configuration (`getProject`) — is cached on disk so it is shared across processes. Because every TDPM invocation is a fresh process, an in-memory cache alone would re-resolve this metadata over GraphQL on every loop and every worker start; the on-disk cache eliminates that repeated GraphQL traffic. The cache reuses the same `./tmp/cache/{projectName}/` directory convention as the issue cache and writes each entry atomically (to a `.tmp` file then renamed) so concurrent processes never corrupt or read a partial file.
+The mapping from `owner/projectNumber` to the immutable GitHub Project node ID that `GraphqlProjectRepository.fetchProjectId` resolves is cached on disk so it is shared across processes. Because every TDPM invocation is a fresh process, an in-memory cache alone would re-resolve this mapping over GraphQL on every loop and every worker start; the on-disk cache eliminates that repeated GraphQL traffic. The cache reuses the same `./tmp/cache/{projectName}/` directory convention as the issue cache and writes each entry atomically (to a `.tmp` file then renamed) so concurrent processes never corrupt or read a partial file.
 
 ```
 ./tmp/cache/{projectName}/projectId-{owner}:{projectNumber}/{timestamp}.json
-./tmp/cache/{projectName}/project-{projectId}/{timestamp}.json
 ```
 
 - The `projectId` mapping (`owner/projectNumber` to project node ID) is permanently static, so it is reused with no time-to-live.
-- The `project` entry is reused only within a time-to-live, because it can change when the project schema is edited. The time-to-live defaults to 30 minutes and is configurable in milliseconds via the `TDPM_PROJECT_CACHE_TTL_MS` environment variable. On a cache hit within the time-to-live the project is returned with zero GraphQL calls; on a miss or expiry it is re-fetched and the cache is rewritten.
+- Only the immutable project node ID is cached. Project metadata that can change — the project's fields and single-select status and story options resolved by `getProject` — is intentionally not cached on disk and is fetched fresh from GraphQL on every call, so newly created status and story options are never missed.
 - A malformed or absent cache file falls back to a live GraphQL fetch and never crashes.
 
 ## Per-Project Situation Snapshot

--- a/src/adapter/repositories/GraphqlProjectRepository.diskCache.test.ts
+++ b/src/adapter/repositories/GraphqlProjectRepository.diskCache.test.ts
@@ -14,10 +14,7 @@ jest.mock('ky', () => ({
   __esModule: true,
 }));
 
-import {
-  GraphqlProjectRepository,
-  resolveProjectCacheTtlMs,
-} from './GraphqlProjectRepository';
+import { GraphqlProjectRepository } from './GraphqlProjectRepository';
 import { LocalStorageCacheRepository } from './LocalStorageCacheRepository';
 import { LocalStorageRepository } from './LocalStorageRepository';
 import { Project } from '../../domain/entities/Project';
@@ -98,7 +95,6 @@ const buildCacheStub = (overrides?: {
 
 describe('GraphqlProjectRepository disk cache', () => {
   const localStorageRepository = new LocalStorageRepository();
-  const thirtyMinutesMs = 30 * 60 * 1000;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -109,23 +105,8 @@ describe('GraphqlProjectRepository disk cache', () => {
     jest.useRealTimers();
   });
 
-  describe('resolveProjectCacheTtlMs', () => {
-    it('defaults to 30 minutes when unset', () => {
-      expect(resolveProjectCacheTtlMs(undefined)).toBe(thirtyMinutesMs);
-    });
-
-    it('uses the configured millisecond value when valid', () => {
-      expect(resolveProjectCacheTtlMs('60000')).toBe(60000);
-    });
-
-    it('falls back to the default for non-numeric or negative values', () => {
-      expect(resolveProjectCacheTtlMs('abc')).toBe(thirtyMinutesMs);
-      expect(resolveProjectCacheTtlMs('-1')).toBe(thirtyMinutesMs);
-    });
-  });
-
   describe('getProject', () => {
-    it('fetches via GraphQL and writes the cache on a cache miss', async () => {
+    it('always fetches the project fresh via GraphQL without reading or writing the disk cache', async () => {
       const cache = buildCacheStub();
       mockPost.mockReturnValueOnce(mockJsonResponse(getProjectResponse));
       const repository = new GraphqlProjectRepository(
@@ -138,75 +119,14 @@ describe('GraphqlProjectRepository disk cache', () => {
 
       expect(project).toEqual(expectedProject);
       expect(mockPost).toHaveBeenCalledTimes(1);
-      expect(cache.set).toHaveBeenCalledWith(
-        `project-${projectId}`,
-        expectedProject,
-      );
-    });
-
-    it('returns the cached project without any GraphQL call when the cache is fresh', async () => {
-      const cache = buildCacheStub({
-        getLatest: jest.fn().mockResolvedValue({
-          value: expectedProject,
-          timestamp: new Date(),
-        } satisfies CacheEntry),
-      });
-      const repository = new GraphqlProjectRepository(
-        localStorageRepository,
-        'dummy',
-        cache,
-      );
-
-      const project = await repository.getProject(projectId);
-
-      expect(project).toEqual(expectedProject);
-      expect(mockPost).not.toHaveBeenCalled();
+      expect(cache.getLatest).not.toHaveBeenCalled();
       expect(cache.set).not.toHaveBeenCalled();
     });
 
-    it('refetches via GraphQL when the cached entry is older than the TTL', async () => {
-      const staleTimestamp = new Date(Date.now() - thirtyMinutesMs - 1);
+    it('does not serve a project from the disk cache even when one is present', async () => {
       const cache = buildCacheStub({
         getLatest: jest.fn().mockResolvedValue({
           value: expectedProject,
-          timestamp: staleTimestamp,
-        } satisfies CacheEntry),
-      });
-      mockPost.mockReturnValueOnce(mockJsonResponse(getProjectResponse));
-      const repository = new GraphqlProjectRepository(
-        localStorageRepository,
-        'dummy',
-        cache,
-      );
-
-      const project = await repository.getProject(projectId);
-
-      expect(project).toEqual(expectedProject);
-      expect(mockPost).toHaveBeenCalledTimes(1);
-      expect(cache.set).toHaveBeenCalledTimes(1);
-    });
-
-    it('falls back to a live GraphQL fetch when the cache read throws', async () => {
-      const cache = buildCacheStub({
-        getLatest: jest.fn().mockRejectedValue(new Error('corrupted file')),
-      });
-      mockPost.mockReturnValueOnce(mockJsonResponse(getProjectResponse));
-      const repository = new GraphqlProjectRepository(
-        localStorageRepository,
-        'dummy',
-        cache,
-      );
-
-      const project = await repository.getProject(projectId);
-
-      expect(project).toEqual(expectedProject);
-      expect(mockPost).toHaveBeenCalledTimes(1);
-    });
-
-    it('falls back to a live GraphQL fetch when the cached value is malformed', async () => {
-      const cache = buildCacheStub({
-        getLatest: jest.fn().mockResolvedValue({
-          value: { unexpected: 'shape' },
           timestamp: new Date(),
         } satisfies CacheEntry),
       });
@@ -221,27 +141,7 @@ describe('GraphqlProjectRepository disk cache', () => {
 
       expect(project).toEqual(expectedProject);
       expect(mockPost).toHaveBeenCalledTimes(1);
-    });
-
-    it('respects a custom TTL passed to the constructor', async () => {
-      const cache = buildCacheStub({
-        getLatest: jest.fn().mockResolvedValue({
-          value: expectedProject,
-          timestamp: new Date(Date.now() - 2000),
-        } satisfies CacheEntry),
-      });
-      mockPost.mockReturnValueOnce(mockJsonResponse(getProjectResponse));
-      const repository = new GraphqlProjectRepository(
-        localStorageRepository,
-        'dummy',
-        cache,
-        1000,
-      );
-
-      const project = await repository.getProject(projectId);
-
-      expect(project).toEqual(expectedProject);
-      expect(mockPost).toHaveBeenCalledTimes(1);
+      expect(cache.set).not.toHaveBeenCalled();
     });
   });
 

--- a/src/adapter/repositories/GraphqlProjectRepository.ts
+++ b/src/adapter/repositories/GraphqlProjectRepository.ts
@@ -1,5 +1,4 @@
 import ky from 'ky';
-import typia from 'typia';
 import { BaseGitHubRepository } from './BaseGitHubRepository';
 import { LocalStorageCacheRepository } from './LocalStorageCacheRepository';
 import { LocalStorageRepository } from './LocalStorageRepository';
@@ -9,23 +8,7 @@ import { normalizeFieldName } from './utils';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
-const DEFAULT_PROJECT_CACHE_TTL_MS = 30 * 60 * 1000;
-
-export const resolveProjectCacheTtlMs = (
-  rawValue: string | undefined,
-): number => {
-  if (rawValue === undefined) {
-    return DEFAULT_PROJECT_CACHE_TTL_MS;
-  }
-  const parsed = Number(rawValue);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return DEFAULT_PROJECT_CACHE_TTL_MS;
-  }
-  return parsed;
-};
-
 const PROJECT_ID_DISK_CACHE_KEY_PREFIX = 'projectId';
-const PROJECT_DISK_CACHE_KEY_PREFIX = 'project';
 
 export const convertToFieldOptionColor = (
   color: string,
@@ -63,19 +46,14 @@ export class GraphqlProjectRepository
     LocalStorageCacheRepository,
     'getLatest' | 'set'
   >;
-  private readonly projectCacheTtlMs: number;
 
   constructor(
     localStorageRepository: LocalStorageRepository,
     ghToken: string = process.env.GH_TOKEN || 'dummy',
     projectCache?: Pick<LocalStorageCacheRepository, 'getLatest' | 'set'>,
-    projectCacheTtlMs: number = resolveProjectCacheTtlMs(
-      process.env.TDPM_PROJECT_CACHE_TTL_MS,
-    ),
   ) {
     super(localStorageRepository, ghToken);
     this.projectCache = projectCache;
-    this.projectCacheTtlMs = projectCacheTtlMs;
   }
 
   private readProjectIdFromDiskCache = async (
@@ -115,50 +93,6 @@ export class GraphqlProjectRepository
       await this.projectCache.set(
         `${PROJECT_ID_DISK_CACHE_KEY_PREFIX}-${cacheKey}`,
         { projectId },
-      );
-    } catch (error) {
-      return;
-    }
-  };
-
-  private readProjectFromDiskCache = async (
-    projectId: string,
-  ): Promise<Project | null> => {
-    if (!this.projectCache) {
-      return null;
-    }
-    let cache: { value: object; timestamp: Date } | null;
-    try {
-      cache = await this.projectCache.getLatest(
-        `${PROJECT_DISK_CACHE_KEY_PREFIX}-${projectId}`,
-      );
-    } catch (error) {
-      return null;
-    }
-    if (!cache) {
-      return null;
-    }
-    const age = Date.now() - cache.timestamp.getTime();
-    if (age >= this.projectCacheTtlMs) {
-      return null;
-    }
-    if (!typia.is<Project>(cache.value)) {
-      return null;
-    }
-    return cache.value;
-  };
-
-  private writeProjectToDiskCache = async (
-    projectId: string,
-    project: Project,
-  ): Promise<void> => {
-    if (!this.projectCache) {
-      return;
-    }
-    try {
-      await this.projectCache.set(
-        `${PROJECT_DISK_CACHE_KEY_PREFIX}-${projectId}`,
-        project,
       );
     } catch (error) {
       return;
@@ -280,10 +214,6 @@ export class GraphqlProjectRepository
     return await this.fetchProjectId(owner, projectNumber);
   };
   getProject = async (projectId: Project['id']): Promise<Project | null> => {
-    const diskCached = await this.readProjectFromDiskCache(projectId);
-    if (diskCached) {
-      return diskCached;
-    }
     const query = `query GetProjectV2($projectId: ID!) {
   node(id: $projectId) {
     ... on ProjectV2 {
@@ -428,7 +358,7 @@ export class GraphqlProjectRepository
     const completionDate50PercentConfidence = project.fields.nodes.find(
       (field) => normalizeFieldName(field.name).startsWith('completiondate'),
     );
-    const result: Project = {
+    return {
       id: project.id,
       url: project.url,
       databaseId: project.databaseId,
@@ -489,8 +419,6 @@ export class GraphqlProjectRepository
           }
         : null,
     };
-    await this.writeProjectToDiskCache(projectId, result);
-    return result;
   };
   getByUrl = async (url: string): Promise<Project> => {
     const projectId = await this.findProjectIdByUrl(url);


### PR DESCRIPTION
From: :robot: HS AI Agent (claude-opus-4-8)

## Summary

Commit a8ac43f ("feat(project-repository): cache static project metadata to disk across processes", released as version 1.109.0) added two on-disk cache entries to `GraphqlProjectRepository`:

1. `projectId-{owner}:{projectNumber}` storing only the immutable project node ID, with no time-to-live.
2. `project-{projectId}` storing the entire `Project` object, including the Status and story single-select field option lists, with a 30-minute time-to-live.

The second entry is unsafe. The story field is an Epic field whose options change constantly as new stories are created, so caching those option lists on disk goes stale within the time-to-live and the daemon misses newly created story and status options.

## Change

This pull request keeps the immutable project ID disk cache and removes the project-metadata (Status / story options) disk cache:

- Removes the `project-{projectId}` disk read and write paths and the time-to-live machinery (`projectCacheTtlMs`, `DEFAULT_PROJECT_CACHE_TTL_MS`, `TDPM_PROJECT_CACHE_TTL_MS` handling, `resolveProjectCacheTtlMs`, `readProjectFromDiskCache`, `writeProjectToDiskCache`), so `getProject` fetches fresh from GraphQL on every call exactly as it did before a8ac43f.
- Keeps the `projectId-{owner}:{projectNumber}` disk cache intact, because the project node ID mapping is immutable and safe to cache across processes.
- Updates the disk-cache unit tests and the README section to reflect that only the immutable project ID is cached.

## Verification

- `npm run build` passes (tsc, no type errors).
- `npm run test` for `GraphqlProjectRepository` and the affected handler tests passes.

Closes #1016

## References

Original feature issue

https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/issues/1003

Commit being narrowed

https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/commit/a8ac43f67870fe6b96945a555015704f3d4cc78f

Tracking issue in the operations repository

https://github.com/HiromiShikata/umino-corporait-operation/issues/29826

Parent issue in the operations repository

https://github.com/HiromiShikata/umino-corporait-operation/issues/29678
