### PR TITLE
Aggregate In-Tmux-by-human sessions across all projects for token-status.json

### DIFF
--- a/src/adapter/entry-points/handlers/HandleScheduledEventUseCaseHandler.ts
+++ b/src/adapter/entry-points/handlers/HandleScheduledEventUseCaseHandler.ts
@@ -496,6 +496,7 @@ export class HandleScheduledEventUseCaseHandler {
           tokenListJsonPath:
             mergedInput.claudeCodeOauthTokenListJsonPath ?? null,
           issues: result.issues,
+          pjcode: input.projectName,
         });
       } catch (error) {
         console.error(

--- a/src/adapter/entry-points/handlers/tokenStatusWriter.test.ts
+++ b/src/adapter/entry-points/handlers/tokenStatusWriter.test.ts
@@ -150,6 +150,84 @@ describe('writeTokenStatus', () => {
     expect(written).toEqual(expected);
   });
 
+  it('aggregates In-Tmux-by-human sessions across multiple projects, not just the last project written', () => {
+    const interactiveSessions: ClaudeInteractiveSession[] = [
+      {
+        token: 'token-a',
+        sessionId: 'session-project-a',
+        issueUrl: 'https://github.com/demo/repo/issues/100',
+      },
+      {
+        token: 'token-a',
+        sessionId: 'session-project-b',
+        issueUrl: 'https://github.com/demo/repo/issues/200',
+      },
+    ];
+    const sharedRepositories = {
+      readSnapshot: () => null,
+      interactiveSessionRepository: {
+        listInteractiveSessions: () => interactiveSessions,
+      },
+      spawnRepository: { listSpawns: () => [] },
+    };
+
+    writeTokenStatus({
+      dashboardDataDir: dir,
+      tokenListJsonPath: tokenListPath,
+      pjcode: 'projectA',
+      issues: [
+        makeIssue({
+          status: 'In Tmux by human',
+          url: 'https://github.com/demo/repo/issues/100',
+        }),
+      ],
+      now,
+      ...sharedRepositories,
+    });
+
+    writeTokenStatus({
+      dashboardDataDir: dir,
+      tokenListJsonPath: tokenListPath,
+      pjcode: 'projectB',
+      issues: [
+        makeIssue({
+          status: 'In Tmux by human',
+          url: 'https://github.com/demo/repo/issues/200',
+        }),
+      ],
+      now,
+      ...sharedRepositories,
+    });
+
+    const written = readJson(path.join(dir, 'token-status.json'));
+    const expectedAlice: TokenStatusFile['tokens'][number] = {
+      name: 'alice',
+      fiveHourUtilizationPercent: null,
+      fiveHourResetSeconds: null,
+      sevenDayUtilizationPercent: null,
+      sevenDayResetSeconds: null,
+      color: 'Y',
+      prep: 0,
+      hum: 2,
+    };
+    expect(written).toEqual({
+      capturedAt: '2026-06-26T12:00:00.000Z',
+      tokens: [
+        expectedAlice,
+        {
+          name: 'bob',
+          fiveHourUtilizationPercent: null,
+          fiveHourResetSeconds: null,
+          sevenDayUtilizationPercent: null,
+          sevenDayResetSeconds: null,
+          color: 'Y',
+          prep: 0,
+          hum: 0,
+        },
+      ],
+    });
+  });
+
   it('is a no-op when dashboardDataDir is unset', () => {
     writeTokenStatus({
       dashboardDataDir: null,

--- a/src/adapter/entry-points/handlers/tokenStatusWriter.ts
+++ b/src/adapter/entry-points/handlers/tokenStatusWriter.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import type { Issue } from '../../../domain/entities/Issue';
+import { IN_TMUX_STATUS_NAME } from '../../../domain/entities/WorkflowStatus';
 import {
   GenerateTokenStatusUseCase,
   TokenRateLimitSnapshot,
@@ -19,10 +20,13 @@ import { ProcTakeOwnershipSpawnRepository } from '../../repositories/ProcTakeOwn
 const SEVEN_DAY_SONNET_LIMIT_TYPE = 'seven_day_sonnet';
 const SEVEN_DAY_OPUS_LIMIT_TYPE = 'seven_day_opus';
 
+const IN_TMUX_PROJECTS_DIR_NAME = 'token-status-in-tmux';
+
 export type TokenStatusWriterParams = {
   dashboardDataDir: string | null | undefined;
   tokenListJsonPath: string | null | undefined;
   issues: Issue[];
+  pjcode?: string | null | undefined;
   now?: Date;
   readSnapshot?: (token: string) => RateLimitSnapshot | null;
   interactiveSessionRepository?: ClaudeInteractiveSessionRepository;
@@ -34,12 +38,76 @@ export type TokenStatusFile = {
   capturedAt: string;
 };
 
+type InTmuxByHumanProjectFile = {
+  pjcode: string;
+  urls: string[];
+  capturedAt: string;
+};
+
 const writeJsonAtomic = (filePath: string, data: unknown): void => {
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
   const tmpPath = `${filePath}.tmp`;
   fs.writeFileSync(tmpPath, JSON.stringify(data));
   fs.renameSync(tmpPath, filePath);
+};
+
+const inTmuxByHumanUrlsFromIssues = (issues: Issue[]): string[] => {
+  const urls = new Set<string>();
+  for (const issue of issues) {
+    if (issue.status === IN_TMUX_STATUS_NAME && issue.isClosed === false) {
+      urls.add(issue.url);
+    }
+  }
+  return [...urls];
+};
+
+const persistProjectInTmuxByHumanUrls = (
+  inTmuxProjectsDir: string,
+  pjcode: string,
+  urls: string[],
+  capturedAt: string,
+): void => {
+  const file: InTmuxByHumanProjectFile = { pjcode, urls, capturedAt };
+  writeJsonAtomic(path.join(inTmuxProjectsDir, `${pjcode}.json`), file);
+};
+
+const readMachineWideInTmuxByHumanUrls = (
+  inTmuxProjectsDir: string,
+): Set<string> => {
+  const urls = new Set<string>();
+  let fileNames: string[];
+  try {
+    fileNames = fs.readdirSync(inTmuxProjectsDir);
+  } catch {
+    return urls;
+  }
+  for (const fileName of fileNames) {
+    if (!fileName.endsWith('.json')) {
+      continue;
+    }
+    try {
+      const parsed: unknown = JSON.parse(
+        fs.readFileSync(path.join(inTmuxProjectsDir, fileName), 'utf8'),
+      );
+      if (
+        parsed === null ||
+        typeof parsed !== 'object' ||
+        !('urls' in parsed) ||
+        !Array.isArray(parsed.urls)
+      ) {
+        continue;
+      }
+      for (const url of parsed.urls) {
+        if (typeof url === 'string') {
+          urls.add(url);
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+  return urls;
 };
 
 export const toTokenRateLimitSnapshot = (
@@ -73,7 +141,7 @@ export const toTokenRateLimitSnapshot = (
 };
 
 export const writeTokenStatus = (params: TokenStatusWriterParams): void => {
-  const { dashboardDataDir, tokenListJsonPath, issues } = params;
+  const { dashboardDataDir, tokenListJsonPath, issues, pjcode } = params;
   if (!dashboardDataDir || !tokenListJsonPath) {
     return;
   }
@@ -82,6 +150,23 @@ export const writeTokenStatus = (params: TokenStatusWriterParams): void => {
   if (entries === null) {
     return;
   }
+
+  const now = params.now ?? new Date();
+  const inTmuxProjectsDir = path.join(
+    dashboardDataDir,
+    IN_TMUX_PROJECTS_DIR_NAME,
+  );
+  if (pjcode) {
+    persistProjectInTmuxByHumanUrls(
+      inTmuxProjectsDir,
+      pjcode,
+      inTmuxByHumanUrlsFromIssues(issues),
+      now.toISOString(),
+    );
+  }
+  const machineWideInTmuxByHumanUrls = pjcode
+    ? readMachineWideInTmuxByHumanUrls(inTmuxProjectsDir)
+    : new Set(inTmuxByHumanUrlsFromIssues(issues));
 
   const readSnapshot = params.readSnapshot ?? readRateLimit;
   const interactiveSessionRepository =
@@ -113,16 +198,43 @@ export const writeTokenStatus = (params: TokenStatusWriterParams): void => {
     token: entry.token,
     snapshot: null,
   }));
+  const machineWideInTmuxByHumanIssues: Issue[] = [
+    ...machineWideInTmuxByHumanUrls,
+  ].map((url) => ({
+    nameWithOwner: '',
+    number: 0,
+    title: '',
+    state: 'OPEN',
+    status: IN_TMUX_STATUS_NAME,
+    story: null,
+    nextActionDate: null,
+    nextActionHour: null,
+    estimationMinutes: null,
+    dependedIssueUrls: [],
+    completionDate50PercentConfidence: null,
+    url,
+    assignees: [],
+    labels: [],
+    org: '',
+    repo: '',
+    body: '',
+    itemId: '',
+    isPr: false,
+    isInProgress: false,
+    isClosed: false,
+    createdAt: now,
+    author: '',
+    closingIssueReferenceUrls: [],
+  }));
   const humResult = new InTmuxByHumanSessionTokenCountUseCase().run(
     candidates,
     interactiveSessionRepository.listInteractiveSessions(),
-    issues,
+    machineWideInTmuxByHumanIssues,
   );
   const humCountByToken = new Map<string, number>(
     humResult.counts.map((count) => [count.token, count.count]),
   );
 
-  const now = params.now ?? new Date();
   const tokens = new GenerateTokenStatusUseCase().run({
     tokens: tokenInputs,
     prepCountByToken,


### PR DESCRIPTION
## Problem

The scheduled-event handler calls `writeTokenStatus` once per project and overwrites the single machine-global `token-status.json` each cycle, passing only that project's issues (`issues: result.issues`). `listInteractiveSessions()` scans interactive sessions machine-wide, but `InTmuxByHumanSessionTokenCountUseCase` filters by the per-project issue set, so only the current project's sessions match. Because each project runs as a separate process and the file is overwritten per project, the last project processed wins, and the dashboard per-token `hum` counts reflect only one project's sessions instead of the machine-wide total.

## Fix

Each project now persists its own In-Tmux-by-human issue URLs to a per-project sidecar file under `token-status-in-tmux/{pjcode}.json`, mirroring the existing per-project pattern used by the in-tmux data writer. `writeTokenStatus` then reads the union of every project's sidecar file and feeds that machine-wide URL set into the in-tmux session count. As a result `token-status.json` aggregates In-Tmux-by-human sessions across all configured projects instead of only the last one written.

- `InTmuxByHumanSessionTokenCountUseCase` and the dashboard composer are unchanged (they remain pure counters/renderers).
- The `token-status.json` schema (`tokens`, `capturedAt`, per-token `prep`/`hum`) is preserved, so the composer renders unchanged.
- When `pjcode` is absent the previous single-set behavior is preserved.

## Test

Added a unit test that writes token status for two projects (`projectA`, `projectB`) with one live In-Tmux-by-human session each and asserts the resulting per-token `hum` count is `2` (both projects counted), proving aggregation across multiple projects rather than only the last project processed.

Closes https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/issues/1020
