### PR TITLE
fix(silent-session): exclude TaskStop-killed and process-crashed subagents from false-positive alerts

### DIFF
--- a/src/adapter/repositories/TranscriptSessionSubAgentActivityRepository.test.ts
+++ b/src/adapter/repositories/TranscriptSessionSubAgentActivityRepository.test.ts
@@ -579,4 +579,196 @@ describe('TranscriptSessionSubAgentActivityRepository', () => {
       { label: 'agent-alivetwo', silentSeconds: 400, runningSeconds: 900 },
     ]);
   });
+
+  const writeMainTranscript = (
+    sessionName: string,
+    lines: object[],
+  ): void => {
+    const filePath = mainTranscriptPathFor(sessionName);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      lines.map((line) => JSON.stringify(line)).join('\n'),
+      'utf8',
+    );
+  };
+
+  const killedNotificationEntry = (
+    agentId: string,
+    timestamp: string,
+  ): object => ({
+    type: 'queue-operation',
+    operation: 'enqueue',
+    timestamp,
+    content: `<task-notification>\n<task-id>${agentId}</task-id>\n<status>killed</status>\n</task-notification>`,
+  });
+
+  const failedNotificationEntry = (
+    agentId: string,
+    timestamp: string,
+  ): object => ({
+    type: 'queue-operation',
+    operation: 'enqueue',
+    timestamp,
+    content: `<task-notification>\n<task-id>${agentId}</task-id>\n<status>failed</status>\n</task-notification>`,
+  });
+
+  const completedNotificationEntry = (
+    agentId: string,
+    timestamp: string,
+  ): object => ({
+    type: 'queue-operation',
+    operation: 'enqueue',
+    timestamp,
+    content: `<task-notification>\n<task-id>${agentId}</task-id>\n<status>completed</status>\n</task-notification>`,
+  });
+
+  it('excludes a sub-agent killed via TaskStop when the parent transcript records a killed notification for its id', async () => {
+    const sessionName = 'https_//github_com/owner/repo/issues/9';
+    const killedAgentId = 'aaabbbbcccc00001';
+    writeAgentTranscript(
+      sessionName,
+      killedAgentId,
+      pendingToolUseEntries('2026-06-27T11:00:00.000Z'),
+      nowEpochSeconds - 300,
+    );
+    writeMainTranscript(sessionName, [
+      killedNotificationEntry(killedAgentId, '2026-06-27T11:55:00.000Z'),
+    ]);
+    const repository = new TranscriptSessionSubAgentActivityRepository(
+      createResolver(),
+      now,
+      noOpCeilingSeconds,
+    );
+
+    const result = await repository.listSubAgentActivitiesBySessionName(
+      [sessionName],
+      transcriptMapFor([sessionName]),
+    );
+
+    expect(result.size).toBe(0);
+  });
+
+  it('excludes a sub-agent whose process crashed when the parent transcript records a failed notification for its id', async () => {
+    const sessionName = 'https_//github_com/owner/repo/issues/9';
+    const failedAgentId = 'aaabbbbcccc00002';
+    writeAgentTranscript(
+      sessionName,
+      failedAgentId,
+      pendingToolUseEntries('2026-06-27T11:00:00.000Z'),
+      nowEpochSeconds - 300,
+    );
+    writeMainTranscript(sessionName, [
+      failedNotificationEntry(failedAgentId, '2026-06-27T11:55:00.000Z'),
+    ]);
+    const repository = new TranscriptSessionSubAgentActivityRepository(
+      createResolver(),
+      now,
+      noOpCeilingSeconds,
+    );
+
+    const result = await repository.listSubAgentActivitiesBySessionName(
+      [sessionName],
+      transcriptMapFor([sessionName]),
+    );
+
+    expect(result.size).toBe(0);
+  });
+
+  it('does not exclude a sub-agent whose parent transcript records only a completed notification for its id', async () => {
+    const sessionName = 'https_//github_com/owner/repo/issues/9';
+    const startTimestamp = '2026-06-27T11:45:00.000Z';
+    const completedAgentId = 'aaabbbbcccc00003';
+    writeAgentTranscript(
+      sessionName,
+      completedAgentId,
+      pendingToolUseEntries(startTimestamp),
+      nowEpochSeconds - 120,
+    );
+    writeMainTranscript(sessionName, [
+      completedNotificationEntry(completedAgentId, '2026-06-27T11:58:00.000Z'),
+    ]);
+    const repository = new TranscriptSessionSubAgentActivityRepository(
+      createResolver(),
+      now,
+      noOpCeilingSeconds,
+    );
+
+    const result = await repository.listSubAgentActivitiesBySessionName(
+      [sessionName],
+      transcriptMapFor([sessionName]),
+    );
+
+    expect(result.get(sessionName)).toEqual([
+      {
+        label: `agent-${completedAgentId}`,
+        silentSeconds: 120,
+        runningSeconds: 900,
+      },
+    ]);
+  });
+
+  it('excludes a killed sub-agent but reports a still-active sibling in the same session', async () => {
+    const sessionName = 'https_//github_com/owner/repo/issues/9';
+    const killedAgentId = 'aaabbbbcccc00004';
+    const aliveAgentId = 'aaabbbbcccc00005';
+    writeAgentTranscript(
+      sessionName,
+      killedAgentId,
+      pendingToolUseEntries('2026-06-27T11:00:00.000Z'),
+      nowEpochSeconds - 600,
+    );
+    writeAgentTranscript(
+      sessionName,
+      aliveAgentId,
+      runningEntries('2026-06-27T11:45:00.000Z'),
+      nowEpochSeconds - 120,
+    );
+    writeMainTranscript(sessionName, [
+      killedNotificationEntry(killedAgentId, '2026-06-27T11:55:00.000Z'),
+    ]);
+    const repository = new TranscriptSessionSubAgentActivityRepository(
+      createResolver(),
+      now,
+      noOpCeilingSeconds,
+    );
+
+    const result = await repository.listSubAgentActivitiesBySessionName(
+      [sessionName],
+      transcriptMapFor([sessionName]),
+    );
+
+    expect(result.get(sessionName)).toEqual([
+      {
+        label: `agent-${aliveAgentId}`,
+        silentSeconds: 120,
+        runningSeconds: 900,
+      },
+    ]);
+  });
+
+  it('reports a sub-agent even when the parent transcript path does not exist', async () => {
+    const sessionName = 'https_//github_com/owner/repo/issues/9';
+    const startTimestamp = '2026-06-27T11:45:00.000Z';
+    writeAgentTranscript(
+      sessionName,
+      'aabb1122cc3344ee',
+      runningEntries(startTimestamp),
+      nowEpochSeconds - 120,
+    );
+    const repository = new TranscriptSessionSubAgentActivityRepository(
+      createResolver(),
+      now,
+      noOpCeilingSeconds,
+    );
+
+    const result = await repository.listSubAgentActivitiesBySessionName(
+      [sessionName],
+      transcriptMapFor([sessionName]),
+    );
+
+    expect(result.get(sessionName)).toEqual([
+      { label: 'agent-aabb1122cc3344ee', silentSeconds: 120, runningSeconds: 900 },
+    ]);
+  });
 });

--- a/src/adapter/repositories/TranscriptSessionSubAgentActivityRepository.ts
+++ b/src/adapter/repositories/TranscriptSessionSubAgentActivityRepository.ts
@@ -91,6 +91,45 @@ const parseTranscript = (content: string): ParsedTranscript => {
 
 const clampToZero = (value: number): number => (value > 0 ? value : 0);
 
+const parseKilledOrFailedAgentIds = (content: string): Set<string> => {
+  const result = new Set<string>();
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!isRecord(parsed)) {
+      continue;
+    }
+    if (readString(parsed, 'type') !== 'queue-operation') {
+      continue;
+    }
+    if (readString(parsed, 'operation') !== 'enqueue') {
+      continue;
+    }
+    const notifContent = readString(parsed, 'content');
+    if (notifContent === null) {
+      continue;
+    }
+    const taskIdMatch = notifContent.match(/<task-id>(a[0-9a-f]+)<\/task-id>/);
+    const statusMatch = notifContent.match(/<status>([^<]+)<\/status>/);
+    if (!taskIdMatch || !statusMatch) {
+      continue;
+    }
+    const status = statusMatch[1];
+    if (status === 'killed' || status === 'failed') {
+      result.add(taskIdMatch[1]);
+    }
+  }
+  return result;
+};
+
 export class TranscriptSessionSubAgentActivityRepository implements SessionSubAgentActivityRepository {
   constructor(
     private readonly directoryResolver: SubAgentTranscriptDirectoryResolver,
@@ -114,7 +153,8 @@ export class TranscriptSessionSubAgentActivityRepository implements SessionSubAg
       if (directory === null) {
         continue;
       }
-      const activities = this.collectActivities(directory, nowEpochSeconds);
+      const killedOrFailedAgentIds = this.loadKilledOrFailedAgentIds(mainTranscriptPath);
+      const activities = this.collectActivities(directory, nowEpochSeconds, killedOrFailedAgentIds);
       if (activities.length > 0) {
         result.set(sessionName, activities);
       }
@@ -122,9 +162,23 @@ export class TranscriptSessionSubAgentActivityRepository implements SessionSubAg
     return result;
   };
 
+  private loadKilledOrFailedAgentIds = (mainTranscriptPath: string | null): Set<string> => {
+    if (mainTranscriptPath === null) {
+      return new Set();
+    }
+    let content: string;
+    try {
+      content = fs.readFileSync(mainTranscriptPath, 'utf8');
+    } catch {
+      return new Set();
+    }
+    return parseKilledOrFailedAgentIds(content);
+  };
+
   private collectActivities = (
     directory: string,
     nowEpochSeconds: number,
+    killedOrFailedAgentIds: Set<string>,
   ): SubAgentActivity[] => {
     let entries: fs.Dirent[];
     try {
@@ -136,6 +190,10 @@ export class TranscriptSessionSubAgentActivityRepository implements SessionSubAg
     for (const entry of entries) {
       const fileName = entry.name;
       if (!fileName.startsWith('agent-') || !fileName.endsWith('.jsonl')) {
+        continue;
+      }
+      const agentId = fileName.slice('agent-'.length, -'.jsonl'.length);
+      if (killedOrFailedAgentIds.has(agentId)) {
         continue;
       }
       const filePath = path.join(directory, fileName);


### PR DESCRIPTION
## Summary

Fixes false-positive silent-session alerts for subagents that were stopped via TaskStop or whose parent Claude Code process crashed.

**Root cause**: When a background agent is killed externally, its transcript ends abruptly without any completion indicator. The existing `entryIndicatesCompletion` check only detects natural completions (end_turn, stop_sequence, final text block) — it cannot detect externally-killed agents. These dead agents were reported as silent/running for up to the full ceiling period (default: 60 minutes).

**Fix**: In `listSubAgentActivitiesBySessionName()`, read the parent session transcript to extract agent IDs from `queue-operation/enqueue` entries with `<status>killed</status>` or `<status>failed</status>`. Skip those agents in `collectActivities()` before inspecting their individual transcripts.

Key insight from live data: `completed` status fires at the end of every normal agent turn and the agent can be resumed — it must **not** be used for exclusion. Only `killed` (explicit TaskStop) and `failed` (parent process crash) reliably mean the agent is permanently done.

Closes https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/issues/1105