### PR TITLE
feat: release two-phase time-precise incremental issue fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,8 @@ The timestamp of the last slow sweep is stored in the `HandleScheduledEvent` Goo
 
 ### Issue cache contract
 
+On each access the repository chooses between a full fetch (when the cache is absent or stale) and a two-phase, time-precise incremental fetch (when the cache is fresh). The incremental path separates a lightweight day-scan phase from a targeted detail-fetch phase, keeping per-cycle GitHub API usage proportional to the number of items updated since the last fetch rather than proportional to total project size.
+
 The issue repository keeps a single always-latest JSON file per project at `./tmp/cache/{projectName}/allIssues-{projectId}/latest.json` and refreshes it on access. Each refresh writes the file atomically (to a `.tmp` file then renamed) and records `lastFetchedAt`, `lastFullFetchAt`, the cached `project`, and the `issues` array in the same file.
 
 - When the cache file is missing or its `lastFullFetchAt` is at least one hour old, the repository fetches every project item, replaces the whole issue list, refreshes the cached `project`, and sets both `lastFullFetchAt` and `lastFetchedAt` to now (`cacheUsed` is `false`).


### PR DESCRIPTION
This pull request exists solely to trigger a new npm release of the feature already merged in https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/pull/1145.

## Background

https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/pull/1145 merged the two-phase time-precise incremental issue fetch into `main`. However, its squash-merge commit title — "Add two-phase time-precise incremental issue fetch" — carried no conventional-commit prefix (`feat:` or `fix:`). As a result, `semantic-release` analyzed the commit, found no releasable change, and did not publish a new version. Both `main` and the npm `latest` tag remain at `1.122.0` even though the feature is fully present in `main`.

## What this PR changes

A brief summary paragraph is added at the top of the "Issue cache contract" section in `README.md` to document the high-level selection logic between the full fetch and the two-phase time-precise incremental fetch.

## Why the `feat:` title prefix matters

On squash-merge, GitHub uses this PR's title as the commit message that `semantic-release` analyzes. The `feat:` prefix causes `semantic-release` to classify it as a new feature and publish `main` HEAD as the next minor version, making the two-phase incremental fetch available via npm.