### PR TITLE
fix(revert-review-queue): contain archived project item update failures so an archived item does not abort the schedule cycle

### DIFF
--- a/src/domain/usecases/RevertNotReadyReviewQueueIssueUseCase.test.ts
+++ b/src/domain/usecases/RevertNotReadyReviewQueueIssueUseCase.test.ts
@@ -1507,4 +1507,194 @@ describe('RevertNotReadyReviewQueueIssueUseCase', () => {
       });
     });
   });
+
+  describe('archived project item containment', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('should skip an archived issue on updateStatus failure and continue with remaining issues', async () => {
+      const archivedIssue = createMockIssue({
+        number: 1,
+        url: 'https://github.com/user/repo/issues/1',
+        itemId: 'archived-item',
+        status: 'Awaiting Quality Check',
+      });
+      const normalIssue = createMockIssue({
+        number: 2,
+        url: 'https://github.com/user/repo/issues/2',
+        itemId: 'normal-item',
+        status: 'Awaiting Quality Check',
+      });
+      mockIssueRepository.getAllIssues.mockResolvedValue({
+        project: mockProject,
+        issues: [archivedIssue, normalIssue],
+        cacheUsed: false,
+      });
+      mockIssueRepository.updateStatus.mockImplementation(
+        (_project: Project, issue: Issue) =>
+          issue.url === archivedIssue.url
+            ? Promise.reject(
+                new Error('The item is archived and cannot be updated'),
+              )
+            : Promise.resolve(undefined),
+      );
+
+      await useCase.run({
+        projectUrl: 'https://github.com/users/user/projects/1',
+        allowedIssueAuthors: ['owner'],
+      });
+
+      expect(mockIssueRepository.updateStatus).toHaveBeenCalledWith(
+        mockProject,
+        archivedIssue,
+        'awaiting-workspace-id',
+      );
+      expect(mockIssueRepository.updateStatus).toHaveBeenCalledWith(
+        mockProject,
+        normalIssue,
+        'awaiting-workspace-id',
+      );
+      expect(mockIssueCommentRepository.createComment).not.toHaveBeenCalledWith(
+        archivedIssue,
+        expect.anything(),
+      );
+      expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+        normalIssue,
+        expect.stringContaining('Auto Status Check: REJECTED'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(archivedIssue.url),
+      );
+    });
+
+    it('should propagate a non-archived updateStatus error for issues unchanged', async () => {
+      const issue = createMockIssue({
+        status: 'Awaiting Quality Check',
+      });
+      mockIssueRepository.getAllIssues.mockResolvedValue({
+        project: mockProject,
+        issues: [issue],
+        cacheUsed: false,
+      });
+      mockIssueRepository.updateStatus.mockRejectedValue(
+        new Error('Something went wrong'),
+      );
+
+      await expect(
+        useCase.run({
+          projectUrl: 'https://github.com/users/user/projects/1',
+          allowedIssueAuthors: ['owner'],
+        }),
+      ).rejects.toThrow('Something went wrong');
+
+      expect(mockIssueCommentRepository.createComment).not.toHaveBeenCalled();
+    });
+
+    it('should skip an archived Unread pull request on updateStatus failure and continue with remaining pull requests', async () => {
+      const archivedPullRequest = createMockPullRequest({
+        number: 1,
+        url: 'https://github.com/user/repo/pull/1',
+        itemId: 'archived-pr-item',
+        status: 'Unread',
+      });
+      const normalPullRequest = createMockPullRequest({
+        number: 2,
+        url: 'https://github.com/user/repo/pull/2',
+        itemId: 'normal-pr-item',
+        status: 'Unread',
+      });
+      mockIssueRepository.getAllIssues.mockResolvedValue({
+        project: mockProject,
+        issues: [archivedPullRequest, normalPullRequest],
+        cacheUsed: false,
+      });
+      mockIssueRepository.getOpenPullRequest.mockImplementation(
+        (prUrl: string) =>
+          Promise.resolve({
+            ...createReadyPr(prUrl),
+            isConflicted: true,
+          }),
+      );
+      mockIssueRepository.updateStatus.mockImplementation(
+        (_project: Project, issue: Issue) =>
+          issue.url === archivedPullRequest.url
+            ? Promise.reject(
+                new Error('The item is archived and cannot be updated'),
+              )
+            : Promise.resolve(undefined),
+      );
+
+      await useCase.run({
+        projectUrl: 'https://github.com/users/user/projects/1',
+        allowedIssueAuthors: ['owner'],
+      });
+
+      expect(mockIssueRepository.updateStatus).toHaveBeenCalledWith(
+        mockProject,
+        archivedPullRequest,
+        'awaiting-workspace-id',
+      );
+      expect(mockIssueRepository.updateStory).not.toHaveBeenCalledWith(
+        expect.anything(),
+        archivedPullRequest,
+        expect.anything(),
+      );
+      expect(mockIssueCommentRepository.createComment).not.toHaveBeenCalledWith(
+        archivedPullRequest,
+        expect.anything(),
+      );
+      expect(mockIssueRepository.updateStatus).toHaveBeenCalledWith(
+        mockProject,
+        normalPullRequest,
+        'awaiting-workspace-id',
+      );
+      expect(mockIssueRepository.updateStory).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'project-1' }),
+        normalPullRequest,
+        'workflow-management-story-id',
+      );
+      expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+        normalPullRequest,
+        expect.stringContaining('Auto Status Check: REJECTED'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(archivedPullRequest.url),
+      );
+    });
+
+    it('should propagate a non-archived updateStatus error for Unread pull requests unchanged', async () => {
+      const pullRequest = createMockPullRequest({
+        status: 'Unread',
+      });
+      mockIssueRepository.getAllIssues.mockResolvedValue({
+        project: mockProject,
+        issues: [pullRequest],
+        cacheUsed: false,
+      });
+      mockIssueRepository.getOpenPullRequest.mockResolvedValue({
+        ...createReadyPr(),
+        isConflicted: true,
+      });
+      mockIssueRepository.updateStatus.mockRejectedValue(
+        new Error('Something went wrong'),
+      );
+
+      await expect(
+        useCase.run({
+          projectUrl: 'https://github.com/users/user/projects/1',
+          allowedIssueAuthors: ['owner'],
+        }),
+      ).rejects.toThrow('Something went wrong');
+
+      expect(mockIssueRepository.updateStory).not.toHaveBeenCalled();
+      expect(mockIssueCommentRepository.createComment).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/domain/usecases/RevertNotReadyReviewQueueIssueUseCase.ts
+++ b/src/domain/usecases/RevertNotReadyReviewQueueIssueUseCase.ts
@@ -10,6 +10,16 @@ import {
   DEFAULT_STATUS_NAME,
 } from '../entities/WorkflowStatus';
 
+// GitHub rejects field mutations against archived project items with
+// "The item is archived and cannot be updated". Such a failure is specific to
+// the single item being reverted, so it must not abort the whole schedule
+// cycle (the same containment policy as the transient GraphQL error handling
+// and the findRelatedOpenPRs NOT_FOUND handling).
+const isArchivedProjectItemError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes('archived');
+};
+
 const isAuthorAuthorizedForAutoStatusCheck = (
   author: string,
   allowedIssueAuthors: string[] | null | undefined,
@@ -113,11 +123,21 @@ export class RevertNotReadyReviewQueueIssueUseCase {
           },
         );
       if (rejections.length > 0) {
-        await this.issueRepository.updateStatus(
-          project,
-          issue,
-          awaitingWorkspaceStatusOption.id,
-        );
+        try {
+          await this.issueRepository.updateStatus(
+            project,
+            issue,
+            awaitingWorkspaceStatusOption.id,
+          );
+        } catch (error) {
+          if (isArchivedProjectItemError(error)) {
+            console.warn(
+              `RevertNotReadyReviewQueueIssueUseCase: project item is archived and cannot be updated, skipping revert. issueUrl: ${issue.url}`,
+            );
+            continue;
+          }
+          throw error;
+        }
         await this.issueCommentRepository.createComment(
           issue,
           `Auto Status Check: REJECTED\n${rejections.map((r) => `- ${r.detail}`).join('\n')}`,
@@ -159,11 +179,21 @@ export class RevertNotReadyReviewQueueIssueUseCase {
         params.labelsAsLlmAgentName ?? [],
       );
       if (rejections.length > 0) {
-        await this.issueRepository.updateStatus(
-          project,
-          pullRequest,
-          awaitingWorkspaceStatusOption.id,
-        );
+        try {
+          await this.issueRepository.updateStatus(
+            project,
+            pullRequest,
+            awaitingWorkspaceStatusOption.id,
+          );
+        } catch (error) {
+          if (isArchivedProjectItemError(error)) {
+            console.warn(
+              `RevertNotReadyReviewQueueIssueUseCase: project item is archived and cannot be updated, skipping revert. prUrl: ${pullRequest.url}`,
+            );
+            continue;
+          }
+          throw error;
+        }
         if (projectStory) {
           await this.issueRepository.updateStory(
             { ...project, story: projectStory },


### PR DESCRIPTION
## Problem

`RevertNotReadyReviewQueueIssueUseCase.run` reverts review queue items to the Awaiting Workspace status via `IssueRepository.updateStatus`. When the target GitHub Project item is archived, `GraphqlProjectItemRepository.updateProjectField` throws `The item is archived and cannot be updated`. This error was not caught, so the whole schedule cycle crashed with exit 1, and every subsequent use case of that cycle (including the silent live-session monitor) was skipped. It recurs every cycle while the archived item keeps matching the revert condition. Observed in production at 2026-07-17 13:22 UTC:

```
Error: The item is archived and cannot be updated
    at GraphqlProjectItemRepository.updateProjectField
    at async ApiV3CheerioRestIssueRepository.updateStatus
    at async RevertNotReadyReviewQueueIssueUseCase.run
    at async HandleScheduledEventUseCase.runEachUseCases
```

## Fix

Following the same containment policy as the existing transient GraphQL error handling and the `findRelatedOpenPRs` NOT_FOUND containment:

- Wrap the per-item `updateStatus` call (both the Awaiting Quality Check issue loop and the Unread pull request loop) in a try/catch.
- When the error message indicates an archived project item (case-insensitive match on `archived`), log a warning with the item URL and skip that item (its rejection comment and story update are also skipped, so nothing half-applied is left behind), then continue with the remaining items.
- Any other error propagates unchanged, preserving existing behavior.

## Tests

Added 4 unit tests in `src/domain/usecases/RevertNotReadyReviewQueueIssueUseCase.test.ts`:

- Archived-item `updateStatus` failure on an Awaiting Quality Check issue is skipped with a warning and the remaining issues are still processed.
- Non-archived `updateStatus` errors for issues still propagate.
- Archived-item `updateStatus` failure on an Unread pull request is skipped with a warning (no story update, no comment) and the remaining pull requests are still processed.
- Non-archived `updateStatus` errors for Unread pull requests still propagate.

Local verification: `eslint src` clean, `tsc -p ./tsconfig.build.json` clean, targeted suite 54/54 passed. The full local `jest` run has 5 pre-existing environment-dependent failing suites that fail identically on unmodified `main` (verified via `git stash`); they are unrelated to this change.

Closes https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/issues/1191
