### PR TITLE
test(ci-status): add coverage for neutral and skipped check run conclusions

### DIFF
--- a/src/adapter/repositories/issue/ApiV3CheerioRestIssueRepository.test.ts
+++ b/src/adapter/repositories/issue/ApiV3CheerioRestIssueRepository.test.ts
@@ -2092,7 +2092,7 @@ describe('ApiV3CheerioRestIssueRepository', () => {
     fetchSpy: FetchSpy,
     predicate: (url: string, body: string) => boolean,
   ): number =>
-    fetchSpy.mock.calls.filter(([input, init]) =>
+    fetchSpy.mock.calls.filter(([input, init]: Parameters<typeof fetch>) =>
       predicate(requestUrlOf(input), requestBodyOf(init)),
     ).length;
 
@@ -2260,6 +2260,28 @@ describe('ApiV3CheerioRestIssueRepository', () => {
         }),
         combinedStatus: () => ({
           statuses: [{ context: 'external-ci', state: 'success' }],
+        }),
+      });
+
+      const { repository } = createApiV3CheerioRestIssueRepository();
+      const result = await repository.getOpenPullRequest(
+        'https://github.com/HiromiShikata/test-repository/pull/31',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.isCiStateSuccess).toBe(true);
+      expect(result?.isPassedAllCiJob).toBe(true);
+    });
+
+    it('returns isCiStateSuccess true when check run conclusions are neutral or skipped', async () => {
+      mockFetchRoutes({
+        slimPullRequest: () => buildSlimPullRequestResponse(),
+        checkRuns: () => ({
+          total_count: 2,
+          check_runs: [
+            { id: 100, name: 'lint', conclusion: 'neutral' },
+            { id: 200, name: 'docs', conclusion: 'skipped' },
+          ],
         }),
       });
 
@@ -2475,14 +2497,17 @@ describe('ApiV3CheerioRestIssueRepository', () => {
             body.includes('headRefOid'),
         ),
       ).toBe(2);
-      const secondSlimCall = fetchSpy.mock.calls
-        .map(([input, init]) =>
+      const secondSlimCall = (
+        fetchSpy.mock.calls as Parameters<typeof fetch>[]
+      )
+        .map(([input, init]): GraphqlRequestBody | null =>
           requestUrlOf(input) === 'https://api.github.com/graphql'
             ? parseGraphqlRequestBody(init)
             : null,
         )
         .filter(
-          (body) => body !== null && body.query.includes('headRefOid'),
+          (body): body is GraphqlRequestBody =>
+            body !== null && body.query.includes('headRefOid'),
         )[1];
       expect(secondSlimCall?.variables.reviewThreadsAfter).toBe('cursor-1');
     });


### PR DESCRIPTION
GitHub's REST check-runs endpoint returns conclusions including `neutral` and `skipped`. These are not failure conclusions and are not pending (non-null), so the CI state evaluator should treat them as passing. This was correct behavior in the implementation but lacked test coverage.

Changes:
- Add unit test verifying `neutral` and `skipped` check run conclusions result in `isCiStateSuccess: true`
- Fix pre-existing TypeScript implicit-any errors in `FetchSpy.mock.calls` usages that caused the test suite to fail to compile (introduced in main by a prior merge)

Closes https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/issues/1201

Related: https://github.com/HiromiShikata/secretary/issues/2275