### PR TITLE
fix(schedule-cycle): contain ky TimeoutError from GitHub GraphQL POST so a request timeout does not abort the schedule cycle

### DIFF
--- a/src/domain/usecases/HandleScheduledEventUseCase.test.ts
+++ b/src/domain/usecases/HandleScheduledEventUseCase.test.ts
@@ -1055,6 +1055,41 @@ describe('HandleScheduledEventUseCase', () => {
         expect(mockIssueRepository.createNewIssue).not.toHaveBeenCalled();
         expect(mockIssueRepository.createCommentByUrl).not.toHaveBeenCalled();
       });
+
+      it('should not create or comment an incident issue for a ky TimeoutError (matched by error name)', async () => {
+        const timeoutError = new Error(
+          'Request timed out: POST https://api.github.com/graphql',
+        );
+        timeoutError.name = 'TimeoutError';
+        mockRevertNotReadyReviewQueueIssueUseCase.run.mockRejectedValueOnce(
+          timeoutError,
+        );
+
+        await expect(useCase.run(errorInput)).rejects.toThrow(
+          'Request timed out',
+        );
+
+        expect(mockIssueRepository.searchIssue).not.toHaveBeenCalled();
+        expect(mockIssueRepository.createNewIssue).not.toHaveBeenCalled();
+        expect(mockIssueRepository.createCommentByUrl).not.toHaveBeenCalled();
+      });
+
+      it('should not create or comment an incident issue for a request timed out error (matched by message)', async () => {
+        const timeoutError = new Error(
+          'Request timed out: POST https://api.github.com/graphql',
+        );
+        mockRevertNotReadyReviewQueueIssueUseCase.run.mockRejectedValueOnce(
+          timeoutError,
+        );
+
+        await expect(useCase.run(errorInput)).rejects.toThrow(
+          'Request timed out',
+        );
+
+        expect(mockIssueRepository.searchIssue).not.toHaveBeenCalled();
+        expect(mockIssueRepository.createNewIssue).not.toHaveBeenCalled();
+        expect(mockIssueRepository.createCommentByUrl).not.toHaveBeenCalled();
+      });
     });
 
     describe('spreadsheet access failure error issue creation', () => {

--- a/src/domain/usecases/HandleScheduledEventUseCase.ts
+++ b/src/domain/usecases/HandleScheduledEventUseCase.ts
@@ -51,7 +51,15 @@ const isTransientApiError = (error: Error): boolean => {
   return (
     /\b(401|403|429|500|502|503|504)\b/.test(msg) ||
     /rate.?limit|RATE_LIMIT/i.test(msg) ||
-    /bad credentials/i.test(msg)
+    /bad credentials/i.test(msg) ||
+    // ky rejects a GitHub GraphQL POST that exceeds its timeout with a
+    // TimeoutError ("Request timed out: POST https://api.github.com/graphql").
+    // Such a timeout is as transient as a 5xx response, so it must not spam
+    // the workflow incident issue. The check is by error name and message so
+    // it matches ky's TimeoutError without a dependency on the ky package
+    // from the domain layer.
+    error.name === 'TimeoutError' ||
+    /request timed out/i.test(msg)
   );
 };
 

--- a/src/domain/usecases/RevertNotReadyReviewQueueIssueUseCase.test.ts
+++ b/src/domain/usecases/RevertNotReadyReviewQueueIssueUseCase.test.ts
@@ -1697,4 +1697,207 @@ describe('RevertNotReadyReviewQueueIssueUseCase', () => {
       expect(mockIssueCommentRepository.createComment).not.toHaveBeenCalled();
     });
   });
+
+  describe('ky TimeoutError containment', () => {
+    let warnSpy: jest.SpyInstance;
+
+    const createKyTimeoutError = (): Error => {
+      const error = new Error(
+        'Request timed out: POST https://api.github.com/graphql',
+      );
+      error.name = 'TimeoutError';
+      return error;
+    };
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('should skip an issue whose updateStatus times out and continue with remaining issues', async () => {
+      const timedOutIssue = createMockIssue({
+        number: 1,
+        url: 'https://github.com/user/repo/issues/1',
+        itemId: 'timed-out-item',
+        status: 'Awaiting Quality Check',
+      });
+      const normalIssue = createMockIssue({
+        number: 2,
+        url: 'https://github.com/user/repo/issues/2',
+        itemId: 'normal-item',
+        status: 'Awaiting Quality Check',
+      });
+      mockIssueRepository.getAllIssues.mockResolvedValue({
+        project: mockProject,
+        issues: [timedOutIssue, normalIssue],
+        cacheUsed: false,
+      });
+      mockIssueRepository.updateStatus.mockImplementation(
+        (_project: Project, issue: Issue) =>
+          issue.url === timedOutIssue.url
+            ? Promise.reject(createKyTimeoutError())
+            : Promise.resolve(undefined),
+      );
+
+      await useCase.run({
+        projectUrl: 'https://github.com/users/user/projects/1',
+        allowedIssueAuthors: ['owner'],
+      });
+
+      expect(mockIssueRepository.updateStatus).toHaveBeenCalledWith(
+        mockProject,
+        timedOutIssue,
+        'awaiting-workspace-id',
+      );
+      expect(mockIssueRepository.updateStatus).toHaveBeenCalledWith(
+        mockProject,
+        normalIssue,
+        'awaiting-workspace-id',
+      );
+      expect(mockIssueCommentRepository.createComment).not.toHaveBeenCalledWith(
+        timedOutIssue,
+        expect.anything(),
+      );
+      expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+        normalIssue,
+        expect.stringContaining('Auto Status Check: REJECTED'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(timedOutIssue.url),
+      );
+    });
+
+    it('should skip an issue whose createComment times out and continue with remaining issues', async () => {
+      const timedOutIssue = createMockIssue({
+        number: 1,
+        url: 'https://github.com/user/repo/issues/1',
+        itemId: 'timed-out-item',
+        status: 'Awaiting Quality Check',
+      });
+      const normalIssue = createMockIssue({
+        number: 2,
+        url: 'https://github.com/user/repo/issues/2',
+        itemId: 'normal-item',
+        status: 'Awaiting Quality Check',
+      });
+      mockIssueRepository.getAllIssues.mockResolvedValue({
+        project: mockProject,
+        issues: [timedOutIssue, normalIssue],
+        cacheUsed: false,
+      });
+      mockIssueCommentRepository.createComment.mockImplementation(
+        (issue: Issue) =>
+          issue.url === timedOutIssue.url
+            ? Promise.reject(createKyTimeoutError())
+            : Promise.resolve(undefined),
+      );
+
+      await useCase.run({
+        projectUrl: 'https://github.com/users/user/projects/1',
+        allowedIssueAuthors: ['owner'],
+      });
+
+      expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+        normalIssue,
+        expect.stringContaining('Auto Status Check: REJECTED'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(timedOutIssue.url),
+      );
+    });
+
+    it('should skip an Unread pull request whose updateStatus times out and continue with remaining pull requests', async () => {
+      const timedOutPullRequest = createMockPullRequest({
+        number: 1,
+        url: 'https://github.com/user/repo/pull/1',
+        itemId: 'timed-out-pr-item',
+        status: 'Unread',
+      });
+      const normalPullRequest = createMockPullRequest({
+        number: 2,
+        url: 'https://github.com/user/repo/pull/2',
+        itemId: 'normal-pr-item',
+        status: 'Unread',
+      });
+      mockIssueRepository.getAllIssues.mockResolvedValue({
+        project: mockProject,
+        issues: [timedOutPullRequest, normalPullRequest],
+        cacheUsed: false,
+      });
+      mockIssueRepository.getOpenPullRequest.mockImplementation(
+        (prUrl: string) =>
+          Promise.resolve({
+            ...createReadyPr(prUrl),
+            isConflicted: true,
+          }),
+      );
+      mockIssueRepository.updateStatus.mockImplementation(
+        (_project: Project, issue: Issue) =>
+          issue.url === timedOutPullRequest.url
+            ? Promise.reject(createKyTimeoutError())
+            : Promise.resolve(undefined),
+      );
+
+      await useCase.run({
+        projectUrl: 'https://github.com/users/user/projects/1',
+        allowedIssueAuthors: ['owner'],
+      });
+
+      expect(mockIssueRepository.updateStatus).toHaveBeenCalledWith(
+        mockProject,
+        timedOutPullRequest,
+        'awaiting-workspace-id',
+      );
+      expect(mockIssueRepository.updateStory).not.toHaveBeenCalledWith(
+        expect.anything(),
+        timedOutPullRequest,
+        expect.anything(),
+      );
+      expect(mockIssueCommentRepository.createComment).not.toHaveBeenCalledWith(
+        timedOutPullRequest,
+        expect.anything(),
+      );
+      expect(mockIssueRepository.updateStatus).toHaveBeenCalledWith(
+        mockProject,
+        normalPullRequest,
+        'awaiting-workspace-id',
+      );
+      expect(mockIssueRepository.updateStory).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'project-1' }),
+        normalPullRequest,
+        'workflow-management-story-id',
+      );
+      expect(mockIssueCommentRepository.createComment).toHaveBeenCalledWith(
+        normalPullRequest,
+        expect.stringContaining('Auto Status Check: REJECTED'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(timedOutPullRequest.url),
+      );
+    });
+
+    it('should propagate a non-timeout non-archived error from createComment unchanged', async () => {
+      const issue = createMockIssue({
+        status: 'Awaiting Quality Check',
+      });
+      mockIssueRepository.getAllIssues.mockResolvedValue({
+        project: mockProject,
+        issues: [issue],
+        cacheUsed: false,
+      });
+      mockIssueCommentRepository.createComment.mockRejectedValue(
+        new Error('Something went wrong'),
+      );
+
+      await expect(
+        useCase.run({
+          projectUrl: 'https://github.com/users/user/projects/1',
+          allowedIssueAuthors: ['owner'],
+        }),
+      ).rejects.toThrow('Something went wrong');
+    });
+  });
 });

--- a/src/domain/usecases/RevertNotReadyReviewQueueIssueUseCase.ts
+++ b/src/domain/usecases/RevertNotReadyReviewQueueIssueUseCase.ts
@@ -20,6 +20,17 @@ const isArchivedProjectItemError = (error: unknown): boolean => {
   return message.toLowerCase().includes('archived');
 };
 
+// ky rejects a GitHub GraphQL POST that exceeds its timeout with a
+// TimeoutError ("Request timed out: POST https://api.github.com/graphql").
+// Such a failure is transient and specific to the single item being
+// processed, so it must not abort the whole schedule cycle (the same
+// containment policy as the transient GraphQL error handling, the
+// findRelatedOpenPRs NOT_FOUND handling, and the archived-item handling).
+// The check is by error name so it matches ky's TimeoutError without a
+// dependency on the ky package from the domain layer.
+const isTimeoutError = (error: unknown): boolean =>
+  error instanceof Error && error.name === 'TimeoutError';
+
 const isAuthorAuthorizedForAutoStatusCheck = (
   author: string,
   allowedIssueAuthors: string[] | null | undefined,
@@ -114,42 +125,53 @@ export class RevertNotReadyReviewQueueIssueUseCase {
         continue;
       }
 
-      const { rejections, approvedPrUrl } =
-        await this.issueRejectionEvaluator.evaluate(
-          issue,
-          params.labelsAsLlmAgentName ?? [],
-          {
-            relatedOpenPrUrls: relatedOpenPrUrlsByIssueUrl.get(issue.url) ?? [],
-          },
-        );
-      if (rejections.length > 0) {
-        try {
-          await this.issueRepository.updateStatus(
-            project,
+      try {
+        const { rejections, approvedPrUrl } =
+          await this.issueRejectionEvaluator.evaluate(
             issue,
-            awaitingWorkspaceStatusOption.id,
+            params.labelsAsLlmAgentName ?? [],
+            {
+              relatedOpenPrUrls:
+                relatedOpenPrUrlsByIssueUrl.get(issue.url) ?? [],
+            },
           );
-        } catch (error) {
-          if (isArchivedProjectItemError(error)) {
-            console.warn(
-              `RevertNotReadyReviewQueueIssueUseCase: project item is archived and cannot be updated, skipping revert. issueUrl: ${issue.url}`,
+        if (rejections.length > 0) {
+          try {
+            await this.issueRepository.updateStatus(
+              project,
+              issue,
+              awaitingWorkspaceStatusOption.id,
             );
-            continue;
+          } catch (error) {
+            if (isArchivedProjectItemError(error)) {
+              console.warn(
+                `RevertNotReadyReviewQueueIssueUseCase: project item is archived and cannot be updated, skipping revert. issueUrl: ${issue.url}`,
+              );
+              continue;
+            }
+            throw error;
           }
-          throw error;
+          await this.issueCommentRepository.createComment(
+            issue,
+            `Auto Status Check: REJECTED\n${rejections.map((r) => `- ${r.detail}`).join('\n')}`,
+          );
+          continue;
         }
-        await this.issueCommentRepository.createComment(
-          issue,
-          `Auto Status Check: REJECTED\n${rejections.map((r) => `- ${r.detail}`).join('\n')}`,
-        );
-        continue;
-      }
 
-      await this.changeTargetPullRequestApprover.approveIfConfined(
-        issue.labels,
-        approvedPrUrl,
-        params.changeTargetPathAliases,
-      );
+        await this.changeTargetPullRequestApprover.approveIfConfined(
+          issue.labels,
+          approvedPrUrl,
+          params.changeTargetPathAliases,
+        );
+      } catch (error) {
+        if (isTimeoutError(error)) {
+          console.warn(
+            `RevertNotReadyReviewQueueIssueUseCase: request timed out, skipping issue for this cycle. issueUrl: ${issue.url} error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          continue;
+        }
+        throw error;
+      }
     }
 
     const projectStory = project.story;
@@ -174,37 +196,47 @@ export class RevertNotReadyReviewQueueIssueUseCase {
         continue;
       }
 
-      const { rejections } = await this.issueRejectionEvaluator.evaluate(
-        pullRequest,
-        params.labelsAsLlmAgentName ?? [],
-      );
-      if (rejections.length > 0) {
-        try {
-          await this.issueRepository.updateStatus(
-            project,
-            pullRequest,
-            awaitingWorkspaceStatusOption.id,
-          );
-        } catch (error) {
-          if (isArchivedProjectItemError(error)) {
-            console.warn(
-              `RevertNotReadyReviewQueueIssueUseCase: project item is archived and cannot be updated, skipping revert. prUrl: ${pullRequest.url}`,
-            );
-            continue;
-          }
-          throw error;
-        }
-        if (projectStory) {
-          await this.issueRepository.updateStory(
-            { ...project, story: projectStory },
-            pullRequest,
-            projectStory.workflowManagementStory.id,
-          );
-        }
-        await this.issueCommentRepository.createComment(
+      try {
+        const { rejections } = await this.issueRejectionEvaluator.evaluate(
           pullRequest,
-          `Auto Status Check: REJECTED\n${rejections.map((r) => `- ${r.detail}`).join('\n')}`,
+          params.labelsAsLlmAgentName ?? [],
         );
+        if (rejections.length > 0) {
+          try {
+            await this.issueRepository.updateStatus(
+              project,
+              pullRequest,
+              awaitingWorkspaceStatusOption.id,
+            );
+          } catch (error) {
+            if (isArchivedProjectItemError(error)) {
+              console.warn(
+                `RevertNotReadyReviewQueueIssueUseCase: project item is archived and cannot be updated, skipping revert. prUrl: ${pullRequest.url}`,
+              );
+              continue;
+            }
+            throw error;
+          }
+          if (projectStory) {
+            await this.issueRepository.updateStory(
+              { ...project, story: projectStory },
+              pullRequest,
+              projectStory.workflowManagementStory.id,
+            );
+          }
+          await this.issueCommentRepository.createComment(
+            pullRequest,
+            `Auto Status Check: REJECTED\n${rejections.map((r) => `- ${r.detail}`).join('\n')}`,
+          );
+        }
+      } catch (error) {
+        if (isTimeoutError(error)) {
+          console.warn(
+            `RevertNotReadyReviewQueueIssueUseCase: request timed out, skipping pull request for this cycle. prUrl: ${pullRequest.url} error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          continue;
+        }
+        throw error;
       }
     }
   };


### PR DESCRIPTION
## Problem

A GitHub GraphQL POST that exceeds ky's timeout rejects with a `TimeoutError` (`Request timed out: POST https://api.github.com/graphql`). This was the fourth uncontained crash path of the schedule cycle: the error bypassed the existing transient-error containment, which only covers GraphQL error responses (200 responses with an `errors` array) and HTTP status errors, and crashed the whole schedule cycle with exit 1 via an unhandled promise rejection. Observed in production on 2026-07-18 at 20:19 UTC on v1.125.0, during the review-queue sweep: the workflow incident issue was created and the cycle then died, skipping all remaining processing of that cycle.

## Fix

Contain ky's `TimeoutError` with the same policy and at the same layer as the existing containment precedents (transient `getOpenPullRequest` errors, `findRelatedOpenPRs` NOT_FOUND, archived project items):

- `RevertNotReadyReviewQueueIssueUseCase`: wrap each per-item processing unit of the Awaiting Quality Check sweep and the Unread pull request sweep in a `TimeoutError` catch that logs a warning and skips only that item, so the remaining items and the remaining use cases of the cycle continue. The existing archived-item catch is kept unchanged inside the new catch.
- `HandleScheduledEventUseCase`: classify `TimeoutError` (matched robustly by error name `TimeoutError` or a `request timed out` message) as a transient API error, so a timeout escaping from any other point of the cycle no longer creates or comments the workflow incident issue.

The timeout check matches by error name so the domain layer does not depend on the ky package. Non-timeout, non-archived errors propagate unchanged.

## Tests

- `RevertNotReadyReviewQueueIssueUseCase.test.ts`: a timed-out `updateStatus` on an issue is skipped with a warning and the remaining issues are still processed; a timed-out `createComment` is skipped the same way; a timed-out `updateStatus` on an Unread pull request is skipped and the remaining pull requests are still processed; a non-timeout, non-archived error still propagates.
- `HandleScheduledEventUseCase.test.ts`: a `TimeoutError` (by name) and a `request timed out` error (by message) are rethrown without creating or commenting the workflow incident issue.
- All existing tests pass: lint, build, and the full jest suite are green locally except two suites (`LocalStorageRepository.integration`, `SqliteClaudeMessageResponseRepository`) that fail identically on a clean main checkout in this environment (Node 26 vs the Node 24 the project pins) and are unrelated to this change.

Closes https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/issues/1210